### PR TITLE
feat: add Multichain USDC to have explicit naming for it

### DIFF
--- a/tokens/FTM.json
+++ b/tokens/FTM.json
@@ -46,5 +46,13 @@
     "decimals": 6,
     "chainId": 250,
     "logoURI": "https://ftmscan.com/token/images/axlusdc_32.png"
+  },
+  {
+    "name": "Multichain USD Coin",
+    "address": "0x04068da6c83afcfa0e13ba15a6696662335d5b75",
+    "symbol": "USDC",
+    "decimals": 6,
+    "chainId": 250,
+    "logoURI": "https://ftmscan.com/token/images/axlusdc_32.png"
   }
 ]


### PR DESCRIPTION
We had this token as our main USDC for FTM in our types package so far. I will replace it with the [LayerZero Version](https://ftmscan.com/address/0x28a92dde19d9989f39a49905d7c9c2fac7799bdf) now. To make sure the old Multichain Token is explicitly named as Multichain, I added it here. We don't want to remove it from our stack since it is still a valid token, just not so important anymore