### PR TITLE
Add $ANIME on base network to custom token list

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -151,5 +151,13 @@
     "decimals": 18,
     "name": "Based Shiba Inu",
     "symbol": "BSHIB"
+  },
+  {
+    "address": "0x0e0c9756a3290cD782CF4aB73ac24D25291c9564",
+    "chainId": 8453,
+    "logoURI": "https://assets.smold.app/api/token/8453/0x0e0c9756a3290cd782cf4ab73ac24d25291c9564/logo.svg",
+    "decimals": 18,
+    "name": "Anime",
+    "symbol": "ANIME"
   }
 ]


### PR DESCRIPTION
We're the number 1 anime and art coin on base network. We have over 50,000 holders. We wish to be added so that our correct information and logo can be shown.

Website:
https://www.animeonbase.art/

CMC:
https://coinmarketcap.com/currencies/anime/

Coingecko:
https://www.coingecko.com/en/coins/anime-base

Basescan:
https://basescan.org/token/0x0e0c9756a3290cD782CF4aB73ac24D25291c9564