### PR TITLE
feat: block MCHC because of unsupported uint96 approvals

### DIFF
--- a/denyTokens/ETH.json
+++ b/denyTokens/ETH.json
@@ -282,5 +282,9 @@
   {
     "address": "0x5a3e6a77ba2f983ec0d371ea3b475f8bc0811ad5",
     "chainId": 1
+  },
+  {
+    "address": "0xd69f306549e9d96f183b1aeca30b8f4353c2ecc3",
+    "chainId": 1
   }
 ]

--- a/denyTokens/ETH.json
+++ b/denyTokens/ETH.json
@@ -285,6 +285,7 @@
   },
   {
     "address": "0xd69f306549e9d96f183b1aeca30b8f4353c2ecc3",
-    "chainId": 1
+    "chainId": 1,
+    "reason": "uint96 approvals do not allow max approval"
   }
 ]


### PR DESCRIPTION

Example: https://www.tdly.co/shared/simulation/e830ee4d-b36d-4981-b9b0-5d47f20712ec