### PR TITLE
fix: remove PAXG from deny list

### DIFF
--- a/denyTokens/ETH.json
+++ b/denyTokens/ETH.json
@@ -9,10 +9,6 @@
   },
   {
     "chainId": 1,
-    "address": "0x45804880de22913dafe09f4980848ece6ecbaf78"
-  },
-  {
-    "chainId": 1,
     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828"
   },
   {


### PR DESCRIPTION
Blockchain.com wants this token, I did two test txs:

To PAXG: https://etherscan.io/tx/0xc67468acd78560b1da2de722b555e7c0cc16b436406f1a70168203cfb80b6727
From PAXG: https://etherscan.io/tx/0x200363e6e9d472d618a913c5eb68edcd9f15369d083eb7d59a63d321c91759de