### PR TITLE
Added J1TFYI token for Solana to SOL.json

### DIFF
--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "J1T.FYI",
+    "address": "HAqD46mR4LgY3aJiMZSabfefZoysG3Uuj6wn2ZKYE14v",
+    "symbol": "J1TFYI",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://ipfs.io/ipfs/bafybeiekidp42xzwnibqeoafifsmeiefr4gjfp5sstpmmxtvvnabgt4afi"
+  }
+]


### PR DESCRIPTION
This PR adds the J1T.FYI token to the LI.FI Solana token list, enabling seamless cross-chain bridging, swapping, and aggregation. J1T.FYI leverages exclusive tokenomics to set a new standard for rarity and value. By integrating with LI.FI’s advanced aggregation stack of DEXs, DEX aggregators, and solvers, this addition enhances multi-chain support and liquidity, facilitating any-to-any swaps involving J1T.FYI across supported chains.

Token Details
	•	Name: J1T.FYI
	•	Symbol: J1TFYI
	•	Address: HAqD46mR4LgY3aJiMZSabfefZoysG3Uuj6wn2ZKYE14v
	•	Decimals: 9
	•	Chain: Solana (Chain ID: 1151111081099710)
	•	Logo URL: https://ipfs.io/ipfs/bafybeiekidp42xzwnibqeoafifsmeiefr4gjfp5sstpmmxtvvnabgt4afi

Links & Validation
	•	Website: https://j1t.fyi/
	•	DexTools: https://www.dextools.io/token/j1tfyi
	•	DexScreener: https://dexscreener.com/solana/dy9enh8en61abfkbajk3yb8cg6dmywjpmj2ppyibvdtm
	•	Moralis: https://moralis.com/chain/solana/token/price/j-1-tfyi-1
	•	GeckoTerminal: https://www.geckoterminal.com/solana/pools/Dy9ENH8en61ABFkBaJk3YB8CG6DMYwjpmj2PpyibvdTm
	•	BirdEye: https://www.birdeye.so/token/HAqD46mR4LgY3aJiMZSabfefZoysG3Uuj6wn2ZKYE14v?chain=solana

Social Links
	•	Twitter: https://x.com/j1tfyi
	•	Telegram: https://t.me/j1tfyi

The J1TFYI token is a one-of-a-kind, digital asset that redefines the concept of scarcity and exclusivity in the blockchain space. Unlike traditional tokens with infinite minting, J1TFYI has only one token in existence, meticulously divided into 9 decimals for precision and access. Built on the Solana blockchain, it offers blazing-fast speed, low fees, and unparalleled efficiency.
