### PR TITLE
add midas tokens to eth and base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -206,7 +206,7 @@
     "decimals": 18,
     "name": "Anime",
     "symbol": "ANIME"
-  }, 
+  },
   {
     "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
     "chainId": 8453,
@@ -238,5 +238,21 @@
     "decimals": 18,
     "name": "Derive",
     "symbol": "DRV"
+  },
+  {
+    "name": "mBASIS",
+    "address": "0x1C2757c1FeF1038428b5bEF062495ce94BBe92b2",
+    "symbol": "mBASIS",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/50593/standard/mBASIS_logo.png?1728444389"
+  },
+  {
+    "name": "mTBILL",
+    "address": "0xDD629E5241CbC5919847783e6C96B2De4754e438",
+    "symbol": "mTBILL",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/37839/standard/mTBILL_token.png?1728417279"
   }
 ]

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -366,5 +366,29 @@
     "decimals": 18,
     "name": "Derive",
     "symbol": "DRV"
+  },
+  {
+    "name": "mBASIS",
+    "address": "0x2a8c22E3b10036f3AEF5875d04f8441d4188b656",
+    "symbol": "mBASIS",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/50593/standard/mBASIS_logo.png?1728444389"
+  },
+  {
+    "name": "mTBILL",
+    "address": "0xdd629e5241cbc5919847783e6c96b2de4754e438",
+    "symbol": "mTBILL",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/37839/standard/mTBILL_token.png?1728417279"
+  },
+  {
+    "name": "mBTC",
+    "address": "0x007115416AB6c266329a03B09a8aa39aC2eF7d9d",
+    "symbol": "mBTC",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/51055/standard/mbtc.png?1729875716"
   }
 ]


### PR DESCRIPTION
Adding Midas ethereum and base token to the List. Here the project information:

- Website: https://midas.app
- Blog: https://blog.midas.app/midas-raises-8-75-million-funding-round-led-by-framework-ventures-blocktower-and-hv-capital/

- Coingecko
  - mBASIS: https://www.coingecko.com/en/coins/midas-basis-trading-token
  - mTBILL: https://www.coingecko.com/en/coins/midas-mtbill
  - mBTC: https://www.coingecko.com/en/coins/midas-btc-yield-token