### PR TITLE
fix: deny Pi Network token

### DIFF
--- a/denyTokens/BSC.json
+++ b/denyTokens/BSC.json
@@ -249,6 +249,10 @@
   },
   {
     "chainId": 56,
+    "address": "0x47265DbfA372E6bd83Fd3B5AA42dBdfD46f97801"
+  },
+  {
+    "chainId": 56,
     "address": "0x723dc7dd87ddb9d10465ad734cfb038ea233d15b"
   }
 ]


### PR DESCRIPTION
Pi Network token transfered the entire amount to it's token address and took 100% fee. 

tx: https://scan.li.fi/tx/0x3e3766bafdbc6f44d00e26fdf2aec5bd99ea5a9092cde29cf73afbe94a2ba283