### PR TITLE
feat: add PBTC on BAS

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -462,5 +462,13 @@
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/parallel-protocol/parallel-brand-kit/main/Tokens/PRL/PRL.svg"
+  },
+  {
+    "name": "PepeBitcoin",
+    "address": "0x31705474c1F2DE7F738E34233c49522CA1E3C53c",
+    "symbol": "PBTC",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://www.pepe-bitcoin.com/media/PBTC_logo_32x32.svg"
   }
 ]


### PR DESCRIPTION
This PR adds PepeBitcoin (PBTC) on Base to the LiFi token list so users can swap directly into PBTC from any supported chain and our logo is displayed correctly.
PBTC is the native token of the PepeBitcoin ecosystem and will be used for token launches, staking, and merch payments. There is clear demand from our community for cross chain swaps. We already used the Li.Fi SDK for our presale and want to add the widget to our website now to allow investors to buy from different chains.

Validation:
Website: https://www.pepe-bitcoin.com/
Whitepaper: https://www.pepe-bitcoin.com/media/PBTC_whitepaper_v2.pdf
DexScreener: https://dexscreener.com/base/0xc3fd337dfc5700565a5444e3b0723920802a426d
X: [https://twitter.com/SebastianSalmhofer Telegram: https://t.me/PepeBitcoinOfficial](https://x.com/PepeBitcoinPBTC)
GitHub: https://github.com/PepeBitcoin