### PR TITLE
feat: add ArchAI token on Base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -470,5 +470,13 @@
     "chainId": 8453,
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/54873/standard/defi-app.png?1742235743"
+  },
+  {
+    "name": "ArchAI",
+    "address": "0xd3b0b58ec9516e4b875a075328e2cb059d4d54db",
+    "symbol": "archai",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/55531/standard/logo_blue.png?1749832743"
   }
 ]


### PR DESCRIPTION
Dear LiFinance Team,

Can you please add the ArchAI token by merging this PR?

Here are some details:
- Token in the explorer: https://basescan.org/token/0xd3b0b58ec9516e4b875a075328e2cb059d4d54db#readContract 
- Project Link: https://thearch.ai/
- CoinGecko: https://www.coingecko.com/en/coins/archai
- Coinmarketcap: https://coinmarketcap.com/currencies/bad-coin/

Let me know if you have further questions.