### PR TITLE
feat: add fusdc to arb token list; add scam fusdc to deny list

### DIFF
--- a/denyTokens/ARB.json
+++ b/denyTokens/ARB.json
@@ -23,5 +23,10 @@
     "address": "0x99ed7e54ed287f8e603bca5932abfa812eec4f3c",
     "chainId": 42161,
     "reason": "Scam USDC - https://gopluslabs.io/token-security/42161/0x99ED7E54ed287f8e603bcA5932abFA812EEC4f3c"
+  },
+  {
+    "address": "0xCfA801cb926Ed09F0E61Aa034194a88f595aFFfF",
+    "chainId": 42161,
+    "reason": "Scam fUSDC"
   }
 ]

--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -446,5 +446,13 @@
     "decimals": 18,
     "chainId": 42161,
     "logoURI": "https://assets.coingecko.com/coins/images/14932/standard/CTX_Logo_200px.png"
+  },
+  {
+    "name": "Fluid USDC",
+    "symbol": "fUSDC",
+    "address": "0x4CFA50B7Ce747e2D61724fcAc57f24B748FF2b2A",
+    "decimals": 6,
+    "chainId": 42161,
+    "logoURI": "https://static.debank.com/image/arb_token/logo_url/0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a/6375f8b48700517096bed5cbd88a2102.png"
   }
 ]


### PR DESCRIPTION
Relates to: https://lifi.atlassian.net/browse/LF-14190
Relates to support thread: https://lifi-protocol.slack.com/archives/C08CRMSFHR9/p1749785267108469

- Adds official fUSDC to ARB custom list
- Adds scam fUSDC to ARB deny list