### PR TITLE
fix: replace stXTZ logo URI (ETL)

### DIFF
--- a/tokens/ETL.json
+++ b/tokens/ETL.json
@@ -53,6 +53,6 @@
     "address": "0x01F07f4d78d47A64F4C3B2b65f513f15Be6E1854",
     "decimals": 6,
     "chainId": 42793,
-    "logoURI": "https://ipfs.io/ipfs/QmVQGUYVmuUnsLWvakjT3w1wuU8fFoy98yaAKtpwBR4TKL"
+    "logoURI": "https://static.debank.com/image/ethlink_token/logo_url/0x01f07f4d78d47a64f4c3b2b65f513f15be6e1854/dc94542c22dc4c0a0b505574e17d1d8a.png"
   }
 ]


### PR DESCRIPTION
stXTZ isn't showing up on the Jumper UI, but the others are. Seeing if replacing the logo URI helps.