### PR TITLE
feat: added XBG token on ARB

### DIFF
--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -494,5 +494,13 @@
     "decimals": 0,
     "name": "crow with knife",
     "symbol": "CAW"
+  },
+  {
+    "address": "0x93FA0B88C0C78e45980Fa74cdd87469311b7B3E4",
+    "chainId": 42161,
+    "logoURI": "https://assets.coingecko.com/coins/images/39830/standard/XBorg_Logo.png?1724209192",
+    "decimals": 18,
+    "name": "XBorg",
+    "symbol": "XBG"
   }
 ]


### PR DESCRIPTION
Added support for the XBG token on Arbitrum

Arbiscan: https://arbiscan.io/token/0x93FA0B88C0C78e45980Fa74cdd87469311b7B3E4
Coingecko info at: https://www.coingecko.com/en/coins/xborg
Whitepaper: https://dev-xborg-image-temp.s3.eu-north-1.amazonaws.com/Litepaper+Cover+Page-merged.pdf
Project: https://www.xborg.com/
