### PR TITLE
feat: Add KITTY on Cronos - CRO.json

### DIFF
--- a/tokens/CRO.json
+++ b/tokens/CRO.json
@@ -6,5 +6,13 @@
     "decimals": 18,
     "name": "crow with knife",
     "symbol": "CAW"
+  },
+  {
+    "address": "0x4d7c922D6C12CfbF5BC85F56c9ccB1F61f49bf61",
+    "chainId": 25,
+    "logoURI": "https://dd.dexscreener.com/ds-data/tokens/cronos/0x4d7c922d6c12cfbf5bc85f56c9ccb1f61f49bf61.png?size=lg&key=da6d50",
+    "decimals": 18,
+    "name": "KitCoin",
+    "symbol": "KITTY"
   }
 ]


### PR DESCRIPTION
KitCoin (KITTY) is a long established token on Cronos (1 year & 3 months). KitCoin has developed an NFT collection & also a DApp CroVegas.Fun listed on DappRadar, DefiLlama, Cronos Discover & Crypto.com's OnChain Wallet. This PR adds its token (KITTY) information to CRO.json Please find below information in the links below for verification.

Website: https://www.kitcoin.io/
Cronoscan: https://cronoscan.com/token/0x4d7c922D6C12CfbF5BC85F56c9ccB1F61f49bf61
DexScreener: https://dexscreener.com/cronos/0xdc1ff76d4737b2F54bbF42656FB998650b7A2b00
GeckoTerminal: https://www.geckoterminal.com/cro/pools/0xdc1ff76d4737b2f54bbf42656fb998650b7a2b00
X: https://x.com/kitcoinx
MemesOnCronos: https://www.memesoncronos.com/tokens/kitcoin
Dapp: https://www.crovegas.fun/
DappRadar: https://dappradar.com/dapp/crovegas