### PR TITLE
feat(lna): add Monerium EURe token

### DIFF
--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -38,5 +38,13 @@
       "decimals": 18,
       "name": "CROAK",
       "logoURI": "https://coin-images.coingecko.com/coins/images/38592/large/Croak-for-coingeko.png?1718092516"
+   },
+   {
+    "address": "0x3ff47c5Bf409C86533FE1f4907524d304062428D",
+    "chainId": 59144,
+    "symbol": "EURe",
+    "decimals": 18,
+    "name": "Monerium EURe",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54303/large/eure.jpg"
    }
  ]


### PR DESCRIPTION
Adding Monerium's EURe token for Linea (LNA).

The token page on Lineascan: https://lineascan.build/token/0x3ff47c5Bf409C86533FE1f4907524d304062428D
Their CoinGecko profile: https://www.coingecko.com/en/coins/monerium-eur-money
<img width="422" height="407" alt="image" src="https://github.com/user-attachments/assets/b5e009d0-39eb-4e9c-ac51-29cb91655895" />