### PR TITLE
Update LNA.json

### DIFF
--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -48,3 +48,11 @@
     "logoURI": "https://coin-images.coingecko.com/coins/images/54303/large/eure.jpg"
    }
  ]
+{
+  "address": "0xEb1fD1dBB8aDDA4fa2b5A5C4bcE34F6F20d125D2",
+  "chainId": 59144,
+  "logoURI": "https://assets.coingecko.com/coins/images/51996/standard/Donald_Toad_Transparent.png?1732459916",
+  "decimals": 18,
+  "name": "Donald Toad Coin",
+  "symbol": "DTC"
+}


### PR DESCRIPTION
This PR adds Donald Toad Coin (DTC) to the LI.FI token list for the Linea chain.
Token address: 0xEb1fD1dBB8aDDA4fa2b5A5C4bcE34F6F20d125D2
Listed on CoinGecko.
Project: https://donaldtoad.com