### PR TITLE
feat(LNA): add REX (Etherex) on Linea mainnet

### DIFF
--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -53,6 +53,6 @@
     "symbol": "REX",
     "decimals": 18,
     "name": "Etherex",
-    "logoURI": "https://static.debank.com/image/linea_token/logo_url/0xefd81eec32b9a8222d1842ec3d99c7532c31e348/cc5fbc3ee5533f3f0ecace4c96e0ab51.png"
+    "logoURI": "https://assets.coingecko.com/coins/images/68009/standard/etherex.jpg"
    }
  ]


### PR DESCRIPTION
Add REX, the token of Etherex. A Linea DEX supported by consensys.

Website: https://www.etherex.finance/trade
X: https://x.com/EtherexFi
Coingecko: https://www.coingecko.com/en/coins/etherex