### PR TITLE
feat: Add token Beaver

### DIFF
--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -70,5 +70,13 @@
       "decimals": 18,
       "name": "Donald Toad Coin",
       "symbol": "DTC"
+    },
+    {
+      "address": "0x880A3Ae90f989030708A529ABd841589053c1dC2",
+      "chainId": 59144,
+      "logoURI": "https://ipfs.io/ipfs/bafkreicwuurlbo4ilkmivzpw7beyiljgykh23ykvvo6yqst5spylnswqo4",
+      "decimals": 18,
+      "name": "Beaver Coin",
+      "symbol": "BEAVER"
     }
 ]


### PR DESCRIPTION
We would like to add our token so that it can be easily searchable by name or symbol, allowing it to be used in trades from day one on DeFi protocols implemented in the Linea ecosystem.

Memecoin profile: https://x.com/BeaverCoin_xyz
Official project profile: https://x.com/beaver_builder
Official Memecoin website: https://beaver-coin.xyz/
Memecoin chart: https://dexscreener.com/linea/0xd643364f9c97bbf76f822b1249570ab0aa4e1044