### PR TITLE
Add wQUIL token

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -662,5 +662,13 @@
     "chainId": 1,
     "decimals": 18,
     "logoURI": "https://dd.dexscreener.com/ds-data/tokens/ethereum/0x0f515f030e31db8fa475aead84f79a5b25a953c4.png?size=lg&key=066039"
+  },
+  {
+    "name": "Wrapped QUIL",
+    "address": "0x8143182a775c54578c8b7b3ef77982498866945d",
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/37978/standard/Wrapped_QUIL.png?1716197853",
+    "decimals": 8,
+    "symbol": "wQUIL"
   }
 ]


### PR DESCRIPTION
- **CoinGecko:** [Wrapped QUIL](https://www.coingecko.com/en/coins/wrapped-quil)  
- **Official Website:** [quilibrium.com](https://quilibrium.com/)  
- **Community Website:** [quilibrium.one](https://quilibrium.one/)

More info:
- Official wrapped version of the Quilibrium Network native token
- Current trading volume: ~$570K daily
- Active on major DEXes: Uniswap, 1inch compatible
- Contract verified on Etherscan
- Over 9,700+ holders
- Market cap: ~$24M
- Part of Quilibrium network ecosystem