### PR TITLE
feat: introduce new listing of legacy EVM tokens requiring an approval reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
-# LI.FI custom tokens
+# LI.FI Custom Tokens
 
 LI.FI supports any token passed to the API as long as we can validate it and find a USD price for it.
 
-The API exposes a list of tokens that UIs can use as default to give their users tokens to choose from. e.g. our widget uses that list: https://li.quest/v1/tokens
+The API exposes a list of tokens that UIs can use as default to give their users tokens to choose from, e.g. our widget uses that list: https://li.quest/v1/tokens
 
 We automatically include tokens in that token list if they are listed in one of the token lists we support:
+
 - lists of assets the bridges support
 - official lists of exchanges we support
 - our own custom token list (this repository)
 
 And if we can validate the token:
+
 - we can find USD prices via Debank or Zerion APIs
 - the token is not a spam/fee-taking token
 
-You can also add scam tokens to /denyTokens/network.json and we will block this token in our system.
+You can also add scam tokens to a blockchain network list in [`/denyTokens/NETX.json`](./denyTokens) and we will block this token in our system.
 
 ## How to add a new chain
 
-We add tokens based on chains. You can find all supported chains through [/chains](https://li.quest/v1/chains) endpoint.
+We add tokens based on chains. You can find all supported chains through our API endpoint [/chains](https://li.quest/v1/chains).
 
-The format of file of a new chain should be `[ChainKey].json` and you can find ChainKey [here](https://docs.li.fi/introduction/chains).
+The format of file of a new chain should be `[ChainKey].json` and you can find ChainKey [in our chains documentation](https://docs.li.fi/introduction/chains).
 
-At the same time, please ensure the package, lifi/types, is the latest version, otherwise you cannot pass the test. You can find it [here](https://github.com/lifinance/types).
+At the same time, please ensure the package `@lifi/types` is the latest version, otherwise you cannot pass the test. You can find it in [this repository](https://github.com/lifinance/types).
 
 ## How to add your token
 
@@ -60,3 +62,11 @@ Add the token as the last element in the list (don't forget the `,` after the pr
 ```
 
 Create a PR with the change describing why we should add that token. Link your project, CoinGecko and profiles so we can validate the token.
+
+## How to report EVM tokens requiring an approval reset
+
+Those lists of ERC-20 tokens help in reporting the need for an initial approval reset transaction prior to setting a new allowance to the spender. Only few legacy tokens are concerned, e.g. USDT on Ethereum mainnet.
+
+To add a legacy token on any of our supported EVM chain, you can create a PR with the token address and chainId reported in corresponding blockchain network file, e.g. [./approvalResetTokens/ETH.json](./approvalResetTokens/ETH.json).
+
+When querying available token swapping routes or quotes, if the source token is in the approval reset list, the need for an approval reset transaction will be indicated via an optional field `approvalReset` in responses' dataset `steps[].estimate`.

--- a/approvalResetTokens/ETH.json
+++ b/approvalResetTokens/ETH.json
@@ -1,0 +1,62 @@
+[
+  {
+    "chainId": 1,
+    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    "note": "Tether USD (USDT)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
+    "note": "Bancor (BNT)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+    "note": "Status (SNT)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+    "note": "Decentraland (MANA)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+    "note": "DENT (DENT)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+    "note": "Lido DAO Token (LDO)"
+  },
+  {
+    "chainId": 1,
+    "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+    "note": "Trace (TRAC) by OriginTrail"
+  },
+  {
+    "chainId": 1,
+    "address": "0x06F3C323f0238c72BF35011071f2b5B7F43A054c",
+    "note": "MASQ (MASQ)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x960b236A07cf122663c4303350609A66A7B288C0",
+    "note": "Aragon (ANT)"
+  },
+  {
+    "chainId": 1,
+    "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
+    "note": "OMG Network (OMG)"
+  },
+  {
+    "chainId": 1,
+    "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+    "note": "Storj (STORJ)"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4470bb87d77b963a013db939be332f927f2b992e",
+    "note": "AdEx (ADX)"
+  }
+]

--- a/approvalResetTokens/ETH.json
+++ b/approvalResetTokens/ETH.json
@@ -6,32 +6,32 @@
   },
   {
     "chainId": 1,
-    "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
+    "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79A7FF1C",
     "note": "Bancor (BNT)"
   },
   {
     "chainId": 1,
-    "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+    "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
     "note": "Status (SNT)"
   },
   {
     "chainId": 1,
-    "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+    "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
     "note": "Decentraland (MANA)"
   },
   {
     "chainId": 1,
-    "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
+    "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
     "note": "DENT (DENT)"
   },
   {
     "chainId": 1,
-    "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+    "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
     "note": "Lido DAO Token (LDO)"
   },
   {
     "chainId": 1,
-    "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+    "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
     "note": "Trace (TRAC) by OriginTrail"
   },
   {
@@ -46,17 +46,17 @@
   },
   {
     "chainId": 1,
-    "address": "0xd26114cd6ee289accf82350c8d8487fedb8a0c07",
+    "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
     "note": "OMG Network (OMG)"
   },
   {
     "chainId": 1,
-    "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
+    "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
     "note": "Storj (STORJ)"
   },
   {
     "chainId": 1,
-    "address": "0x4470bb87d77b963a013db939be332f927f2b992e",
+    "address": "0x4470BB87d77b963A013DB939BE332f927f2b992e",
     "note": "AdEx (ADX)"
   }
 ]


### PR DESCRIPTION
List of all known legacy tokens (base: address & chainId), grouped by chain (EVM ones only) where an extra approval(spender,0) tx is to be initiated & signed by end-users.

Helps in adding a new flag in retrieved routes `routes[].steps[].estimate.approvalReset?` for legacy EVM source tokens potentially requiring an initial `approval(spender,0)` reset tx.

Refer to the approval race condition / front running concern, moreover about the need for adding an extra tx to set an allowance on those legacy tokens.

Context: [LF-8055](https://lifi.atlassian.net/browse/LF-8055)

This pull request adds a new `ETH.json` file to the `approvalResetTokens` directory, listing a set of Ethereum token addresses along with their corresponding notes. This file appears to be intended for tracking or managing approval reset tokens on the Ethereum mainnet.

Token list addition:

* Added `approvalResetTokens/ETH.json` containing an array of base tokens, each specifying a `chainId`, `address`, and `note` for legacy Ethereum tokens such as USDT, BNT, SNT, MANA, DENT, LDO, TRAC, MASQ, ANT, OMG, STORJ, and ADX.

[LF-8055]: https://lifi.atlassian.net/browse/LF-8055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ