### PR TITLE
feat: Add Linea Token to Customized List

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -718,5 +718,13 @@
     "decimals": 6,
     "chainId": 1,
     "logoURI": "https://dashboard.m0.org/img/extensions/musd.png"
+  },
+  {
+    "name": "Linea",
+    "address": "0x1789e0043623282D5DCc7F213d703C6D8BAfBB04",
+    "symbol": "LINEA",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://linea.build/icons/token_round.png"
   }
 ]

--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -94,5 +94,13 @@
       "decimals": 6,
       "name": "Metamask USD",
       "symbol": "mUSD"
+    },
+    {
+      "name": "Linea",
+      "address": "0x1789e0043623282D5DCc7F213d703C6D8BAfBB04",
+      "symbol": "LINEA",
+      "decimals": 18,
+      "chainId": 59144,
+      "logoURI": "https://linea.build/icons/token_round.png"
     }
 ]


### PR DESCRIPTION
This adds the LINEA token for both Ethereum and Mainnet.

There is a round and square variant of the logo also seen at:

https://assets.coingecko.com/coins/images/68507/standard/linea-logo.jpeg?1756025484 and
https://linea.build/icons/token_square.png

This PR explicitly uses the preferred round variant.