### PR TITLE
fix: correct file path

### DIFF
--- a/test/token.validation.unit.spec.ts
+++ b/test/token.validation.unit.spec.ts
@@ -52,7 +52,7 @@ describe('Token validation', () => {
       expect(denyTokenValidator(token)).toBeTruthy()
     })
 
-    it.each(tokensInEachFile('./tokens'))(
+    it.each(tokensInEachFile('./denyTokens'))(
       'should have the same chainId in $fileName file',
       ({ contents }) => {
         const chainIds = contents.map((token: DenyToken) => token.chainId)
@@ -77,7 +77,7 @@ describe('Token validation', () => {
       expect(approvalResetTokenValidator(token)).toBeTruthy()
     })
 
-    it.each(tokensInEachFile('./tokens'))(
+    it.each(tokensInEachFile('./approvalResetTokens'))(
       'should have the same chainId in $fileName file',
       ({ contents }) => {
         const chainIds = contents.map((token: ApprovalResetToken) => token.chainId)


### PR DESCRIPTION
# Description
Fixed incorrect file paths in token validation tests:
- Deny tokens test now reads from `./denyTokens` directory
- Approval reset tokens test now reads from `./approvalResetTokens` directory

Previously these tests were incorrectly using the `./tokens` path, causing validation of wrong files.