### PR TITLE
fix: incorrect token address & removed trailing comma in JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add the token as the last element in the list (don't forget the `,` after the pr
   {
     "address": "0xde3a24028580884448a5397872046a019649b084",
     "chainId": 43114,
-    "reason": "Deprecated USDT token on AVA", <= add an optional reason why the token should be blocked
+    "reason": "Deprecated USDT token on AVA" <= add an optional reason why the token should be blocked
   }
 ]
 ```

--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -1097,7 +1097,7 @@
   },
   {
     "name": "Sprott Nickel Miners",
-    "address": "0x3fcd741646a9790635b938cdb69af5df356cbaab",
+    "address": "0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de",
     "symbol": "NIKLon",
     "decimals": 18,
     "chainId": 56,


### PR DESCRIPTION
1. There were two tokens with the same address in tokens/BSC.json: `0x3fcd741646a9790635b938cdb69af5df356cbaab`

This address is the address of the `abrdn Physical Palladium Shares ETF (Ondo Tokenized ETF)` token.
However, this address was also listed for `Sprott Nickel Miners ETF (Ondo Tokenized)`, although it has a different address: `0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de`

I changed it to the current address and also verified its correctness via [BSCScan](https://bscscan.com/address/0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de) and [Coingecko](https://www.coingecko.com/en/coins/sprott-nickel-miners-etf-ondo-tokenized).

2. In README.md in the example:
```
  },  <== Add the comma
  {
    "address": "0xde3a24028580884448a5397872046a019649b084",
    "chainId": 43114,
    "reason": "Deprecated USDT token on AVA", <= add an optional reason why the token should be blocked
  }
]
```
in the line `“reason”: “Deprecated USDT token on AVA,”` there is an extra comma, which is an error in terms of JSON format, which does not allow trailing commas.

Removed unnecessary comma.
