### PR TITLE
feat: add GYD token to BASE denylist

### DIFF
--- a/denyTokens/BAS.json
+++ b/denyTokens/BAS.json
@@ -33,5 +33,10 @@
     "address": "0xa6BaE8709D2bb09f5ee9785a51842664671A3e97",
     "chainId": 8453,
     "reason": "Malicious token, owner can block sells"
+  },
+  {
+    "address": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+    "chainId": 8453,
+    "reason": "Token has function to pause transfers temporarily"
   }
 ]

--- a/denyTokens/BAS.json
+++ b/denyTokens/BAS.json
@@ -38,6 +38,8 @@
     "address": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
     "chainId": 8453,
     "reason": "Token has function to pause transfers temporarily"
+  },
+  {
     "address": "0x01cbcec2427a5403067e41a829fa74e48b32f1ef",
     "chainId": 8453,
     "reason": "Malicious token, block transfers"


### PR DESCRIPTION
Adding 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8 to BAS.json denylist - token has a pausable transfer function.