### PR TITLE
feat: deny ATH token arb

### DIFF
--- a/denyTokens/ARB.json
+++ b/denyTokens/ARB.json
@@ -48,5 +48,10 @@
     "chainId": 42161,
     "address": "0x4358B2112Fd96771B194CA7c0cb548f46270EC41",
     "reason": "Scam fake EURe token"
+  },
+  {
+    "address": "0xc7dEf82Ba77BAF30BbBc9b6162DC075b49092fb4",
+    "chainId": 42161,
+    "reason": "Illiquid token variant of Aethir token"
   }
 ]

--- a/denyTokens/ARB.json
+++ b/denyTokens/ARB.json
@@ -53,7 +53,8 @@
     "address": "0xc7dEf82Ba77BAF30BbBc9b6162DC075b49092fb4",
     "chainId": 42161,
     "reason": "Illiquid token variant of Aethir token"
-   {
+  },
+  {
     "chainId": 42161,
     "address": "0x327006c8712FE0AbdbbD55B7999DB39b0967342E",
     "reason": "Scam fake PYUSD token"


### PR DESCRIPTION
Deny illiquid Aethir token variant (0xc7dEf82Ba77BAF30BbBc9b6162DC075b49092fb4) on Arbitrum.