### PR TITLE
feat: add Donald Toad Coin (DTC) on Base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -614,5 +614,13 @@
     "decimals": 18,
     "name": "IXS",
     "symbol": "IXS"
+  },
+  {
+    "address": "0xFbA669C72b588439B29F050b93500D8b645F9354",
+    "chainId": 8453,
+    "logoURI": "https://assets.coingecko.com/coins/images/51996/standard/Donald_Toad_Transparent.png?1732459916",
+    "decimals": 18,
+    "name": "Donald Toad Coin",
+    "symbol": "DTC"
   }
 ]


### PR DESCRIPTION
Add Donald Toad Coin (DTC) on Base

This PR adds Donald Toad Coin (DTC) to the Base token list.

Token Details

Name: Donald Toad Coin

Symbol: DTC

Chain: Base (chainId 8453)

Contract: 0xFbA669C72b588439B29F050b93500D8b645F9354

Decimals: 18

About the Project

Donald Toad Coin (DTC) is the native token of the Donald Toad ecosystem, a multi-chain onchain gaming platform featuring risk-based games and skill games such as Intraverse Kart Racers, Cash or Crash and Lilypad Leap. DTC is used for gameplay, rewards, and ecosystem incentives.

DTC is a standard ERC-20 token (no transfer fees, no rebasing).

Links

Website / App: https://donaldtoad.com

Base Explorer: https://basescan.org/token/0xFbA669C72b588439B29F050b93500D8b645F9354

CoinGecko: https://www.coingecko.com/en/coins/donald-toad-coin

Twitter/X: https://x.com/MrDonaldToad

The token is actively traded and already listed on public aggregators and CEX on Linea Network. DTC on Base will be available for trading on Base on Uniswap Q1 2026, alongside our DTC MultiChain bridge using Layer Zero tech and our strategy-risk game called Lilypad Leap. Adding DTC to the LI.FI customized token list enables better routing and visibility for users bridging to and from Base.

Please let me know if any additional information is required.