### PR TITLE
feat: add PUPI token to Linea list

### DIFF
--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -110,5 +110,13 @@
     "decimals": 18,
     "name": "Wrapped Crotch",
     "symbol": "WCROTCH"
+  },
+  {
+    "address": "0x3c56229DBc7dbE69908E3Ad3e2Ba9016b30E83C5",
+    "chainId": 59144,
+    "symbol": "PUPI",
+    "decimals": 18,
+    "name": "PUPI",
+    "logoURI": "https://raw.githubusercontent.com/matthix73-alt/pupi-assets/main/logo.png"
   }
 ]


### PR DESCRIPTION
Adding PUPI token on Linea network. Contract: 0x3c56229DBc7dbE69908E3Ad3e2Ba9016b30E83C5
Proposed PR Description
Summary
This Pull Request adds the PUPI token on the Linea (ChainID: 59144) network to the customized token list. PUPI is the native utility and meme token of the Pupi World ecosystem on Linea.

Token Details

Name: PUPI

Symbol: PUPI

Decimals: 18

Address: 0x3c56229DBc7dbE69908E3Ad3e2Ba9016b30E83C5

Network: Linea

Official Project Links

Website: https://pupi.world/

X (Twitter): https://x.com/pupi_universe

Chart: [https://chart.pupi.world](https://www.google.com/search?q=https://chart.pupi.world)

NFT Marketplace: [https://nft.pupi.world](https://www.google.com/search?q=https://nft.pupi.world)

Quest Platform: [https://quests.pupi.world](https://www.google.com/search?q=https://quests.pupi.world)

Trading Links

PancakeSwap: [https://pancakeswap.pupi.world](https://www.google.com/search?q=https://pancakeswap.pupi.world)

Etherex: [https://etherex.pupi.world](https://www.google.com/search?q=https://etherex.pupi.world)

Lynex: [https://lynex.pupi.world](https://www.google.com/search?q=https://lynex.pupi.world)
