### PR TITLE
feat: add apxUSD and apyUSD tokens to Base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -614,5 +614,21 @@
     "decimals": 18,
     "name": "IXS",
     "symbol": "IXS"
+  },
+  {
+    "address": "0xD993935E13851dd7517af10687EC7e5022127228",
+    "chainId": 8453,
+    "logoURI": "https://assets.apyx.fi/tokens/apxUSD.png",
+    "decimals": 18,
+    "name": "apxUSD",
+    "symbol": "apxUSD"
+  },
+  {
+    "address": "0x2c271ddF484aC0386d216eB7eB9Ff02D4Dc0F6AA",
+    "chainId": 8453,
+    "logoURI": "https://assets.apyx.fi/tokens/apyUSD.png",
+    "decimals": 18,
+    "name": "apyUSD",
+    "symbol": "apyUSD"
   }
 ]


### PR DESCRIPTION
## Summary

- Add **apxUSD** (base dollar, ERC-20) and **apyUSD** (yield vault, ERC-4626) to `tokens/BAS.json`
- Both tokens are newly deployed on Base by [Apyx Finance](https://apyx.fi)

## Token Details

| Token | Address | Decimals | Type |
|-------|---------|----------|------|
| apxUSD | `0xD993935E13851dd7517af10687EC7e5022127228` | 18 | ERC-20 (stablecoin) |
| apyUSD | `0x2c271ddF484aC0386d216eB7eB9Ff02D4Dc0F6AA` | 18 | ERC-4626 (yield vault) |

## References

- Website: https://apyx.fi
- Documentation: https://docs.apyx.fi
- CoinGecko (apxUSD): https://www.coingecko.com/en/coins/apxusd
- Quantstamp Audit: https://certificate.quantstamp.com/full/apx-usd-stablecoin/2a5be074-3d9f-49e7-aa08-46fb5f1e5bd6/index.html
- Logo (apxUSD): https://assets.apyx.fi/tokens/apxUSD.png
- Logo (apyUSD): https://assets.apyx.fi/tokens/apyUSD.png