### PR TITLE
Add Noxcat (NOX) on Arbitrum

### DIFF
--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -216,6 +216,14 @@
     "logoURI": "https://static.debank.com/image/arb_token/logo_url/0x6694340fc020c5e6b96567843da2df01b2ce1eb6/55886c6280173254776780fd8340cca7.png"
   },
   {
+    "address": "0xb23bB8c2C6Cb9169eeaC8f2Bd42fcf333A1a8C55",
+    "chainId": 42161,
+    "symbol": "NOX",
+    "decimals": 18,
+    "name": "Noxcat",
+    "logoURI": "https://drive.google.com/file/d/1rAVo93EjQXAUlyabFiEwyMyXxgY5WszQ/view?usp=drive_link"
+  },  
+  {
     "address": "0xFEa7a6a0B346362BF88A9e4A88416B77a57D6c2A",
     "chainId": 42161,
     "symbol": "MIM",


### PR DESCRIPTION
Add Noxcat (NOX) on Arbitrum

This PR adds NOX to the Arbitrum token list.

Token Details

Name: Noxcat

Symbol: NOX

Chain: Arbitrum (42161)

Contract: 0xb23bB8c2C6Cb9169eeaC8f2Bd42fcf333A1a8C55

Decimals: 18

About the Project

NOXCAT is dedicated to creating a digital ecosystem that rejects complexity and respects intuition — bringing ultimate efficiency into your life. An experience as natural as breathing, yet as solid as a fortress.

$NOX is the native token of the NOXCAT ecosystem, used for platform governance, incentive distribution, and core feature payments.

NOX is a standard ERC-20 token (no transfer fees, no rebasing).

Links

Website / App: https://noxcat.io

Arbiscan: https://arbiscan.io/token/0xb23bB8c2C6Cb9169eeaC8f2Bd42fcf333A1a8C55

CoinGecko: https://www.coingecko.com/en/coins/noxcat

Twitter/X: https://x.com/_noxcat_

Discord: https://discord.gg/BBay7JPDCp

TG: https://t.me/notcat_io

Please let me know if any additional information is required.