### PR TITLE
feat: Add BGB on Morph

### DIFF
--- a/tokens/MOP.json
+++ b/tokens/MOP.json
@@ -1,0 +1,10 @@
+[
+  {
+    "address": "0x389C08Bc23A7317000a1FD76c7c5B0cb0b4640b5",
+    "chainId": 2818,
+    "symbol": "BGB",
+    "decimals": 18,
+    "name": "BitgetToken",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/BGB.svg"
+  }
+]


### PR DESCRIPTION
Add BitgetToken (BGB) on Morph

This PR created Morph token list, and add BGB(Chainlink CCIP) to the Morph token list.

Token Details

Name: BitgetToken

Symbol: BGB

Chain: Morph (2818)

Contract: 0x389C08Bc23A7317000a1FD76c7c5B0cb0b4640b5

Decimals: 18

Explorer: https://explorer.morph.network/token/0x389C08Bc23A7317000a1FD76c7c5B0cb0b4640b5