### PR TITLE
feat: add cbMEGA token on Base and Base Sepolia

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -702,5 +702,13 @@
       "decimals": 18,
       "chainId": 8453,
       "logoURI": "https://raw.githubusercontent.com/curvefi/curve-assets/refs/heads/main/images/assets-etherlink/0x6bde51212203ae5d592cc5180da2abbd41c922de.png"
+  },
+  {
+    "name": "Coinbase Wrapped MEGA",
+    "address": "0xcb111E6A2a3bde90856D299d61341ac302167D23",
+    "symbol": "cbMEGA",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://drive.google.com/uc?export=view&id=1ZZF1v_UH0F5cPHntI8Xs6OBRxmbzYp3H"
   }
 ]

--- a/tokens/BAST.json
+++ b/tokens/BAST.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Coinbase Wrapped MEGA",
+    "address": "0x4eed0aef3d946f552da37ee6e1acb02f057ffff5",
+    "symbol": "cbMEGA",
+    "decimals": 18,
+    "chainId": 84532,
+    "logoURI": "https://drive.google.com/uc?export=view&id=1ZZF1v_UH0F5cPHntI8Xs6OBRxmbzYp3H"
+  }
+]

--- a/tokens/BAST.json
+++ b/tokens/BAST.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Coinbase Wrapped MEGA",
-    "address": "0x4eed0aef3d946f552da37ee6e1acb02f057ffff5",
+    "address": "0x4eeD0aef3d946f552Da37eE6E1Acb02F057Ffff5",
     "symbol": "cbMEGA",
     "decimals": 18,
     "chainId": 84532,


### PR DESCRIPTION
Adds Coinbase Wrapped MEGA (cbMEGA) to the supported token list.

Base mainnet (0xcb111E6A2a3bde90856D299d61341ac302167D23, chainId 8453)
Base Sepolia (0x4eed0aef3d946f552da37ee6e1acb02f057ffff5, chainId 84532)