### PR TITLE
chore: update cbMEGA logoURI

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -709,6 +709,6 @@
     "symbol": "cbMEGA",
     "decimals": 18,
     "chainId": 8453,
-    "logoURI": "https://drive.google.com/uc?export=view&id=1ZZF1v_UH0F5cPHntI8Xs6OBRxmbzYp3H"
+    "logoURI": "https://assets.coingecko.com/coins/images/102173020/standard/megaeth.png?1777256235"
   }
 ]

--- a/tokens/BAST.json
+++ b/tokens/BAST.json
@@ -5,6 +5,6 @@
     "symbol": "cbMEGA",
     "decimals": 18,
     "chainId": 84532,
-    "logoURI": "https://drive.google.com/uc?export=view&id=1ZZF1v_UH0F5cPHntI8Xs6OBRxmbzYp3H"
+    "logoURI": "https://assets.coingecko.com/coins/images/102173020/standard/megaeth.png?1777256235"
   }
 ]


### PR DESCRIPTION
Updates `logoURI` for cbMEGA to the CoinGecko-hosted asset on both Base mainnet and Base Sepolia.

- `tokens/BAS.json` — `0xcb111E6A2a3bde90856D299d61341ac302167D23` (chainId 8453)
- `tokens/BAST.json` — `0x4eeD0aef3d946f552Da37eE6E1Acb02F057Ffff5` (chainId 84532)