### PR TITLE
chore(deny-tokens): deny misleading KAIO token on Ethereum (0xd197…4A37)

### DIFF
--- a/denyTokens/ETH.json
+++ b/denyTokens/ETH.json
@@ -353,5 +353,10 @@
     "address": "0xb1A7F8b3AdA1Cbd7752c1306725b07D2F8B4e726",
     "chainId": 1,
     "reason": "Fake WETH impersonating well-known WETH with inflated marketcap"
+  },
+  {
+    "address": "0xd197526ca57F14934E7f485Df373Fb0904D34A37",
+    "chainId": 1,
+    "reason": "Misleading token identity (KAIO); user received unintended asset — https://jumper.xyz/scan/tx/0x51a47b76b4496b3f3766eef697bc998dd298bbbe33c0e0c2bc497d41a74bbd06"
   }
 ]


### PR DESCRIPTION
## Summary
Adds `0xd197526ca57F14934E7f485Df373Fb0904D34A37` to [`denyTokens/ETH.json`](https://github.com/lifinance/customized-token-list/blob/main/denyTokens/ETH.json) so LI.FI blocks routing to this asset on **Ethereum (chainId 1)**.

## Context
- User ended up with this token after a Jumper swap (misleading **KAIO** identity in LI.FI status).
- Reference tx: https://jumper.xyz/scan/tx/0x51a47b76b4496b3f3766eef697bc998dd298bbbe33c0e0c2bc497d41a74bbd06
- LI.FI status: https://li.quest/v1/status?txHash=0x51a47b76b4496b3f3766eef697bc998dd298bbbe33c0e0c2bc497d41a74bbd06

## Checklist
- [x] `pnpm test` passed locally

Made with [Cursor](https://cursor.com)