### PR TITLE
feat: add wiTRY on megaeth

### DIFF
--- a/tokens/MEG.json
+++ b/tokens/MEG.json
@@ -38,5 +38,13 @@
     "symbol": "USDe",
     "decimals": 18,
     "logoURI": "https://static.debank.com/image/hyper_token/logo_url/0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34/2b2f84856552421d8305bbc71db49979.png"
+  },
+  {
+    "chainId": 4326,
+    "address": "0x15B271D9012b5820FC42b1c495B4C1e206547De5",
+    "name": "Wrapped iTRY",
+    "symbol": "wiTRY",
+    "decimals": 18,
+    "logoURI": "https://assets.brix.money/itry/witry.svg"
   }
 ]


### PR DESCRIPTION
Adds wiTRY (its ERC4626 yield-bearing vault) to the MegaETH official token list. It's LayerZero OFTs with Ethereum as the origin chain and MegaETH as the spoke.

wiTRY
Ethereum (origin, lock): 0xE346C29b5B60Ef870b9724c57ccfbBc631e47DEE
Ethereum bridge (OFT lock adapter): 0x698b7518711bDe4832fDc19F5262DF705c713006
MegaETH (mint OFT): 0x15B271D9012b5820FC42b1c495B4C1e206547De5
Both tokens use 18 decimals. Deployment manifests live in [InverterNetwork/iTry-contracts](https://github.com/InverterNetwork/iTry-contracts).