### PR TITLE
feat: deny BSA (Block Sec Arena) scam token on Base

### DIFF
--- a/denyTokens/BAS.json
+++ b/denyTokens/BAS.json
@@ -48,5 +48,10 @@
     "address": "0x78A315cbE6869Ad13C29e889B973e61b944728D8",
     "chainId": 8453,
     "reason": "Malicious token, block transfers"
+  },
+  {
+    "address": "0xb6E38746AfD8C1dB4481C709AEbf0e3b2794F752",
+    "chainId": 8453,
+    "reason": "BSA (Block Sec Arena) scam token blocking transfers"
   }
 ]


### PR DESCRIPTION
## Summary

- Denies `0xb6E38746AfD8C1dB4481C709AEbf0e3b2794F752` (BSA - Block Sec Arena) on Base (chainId 8453) by adding it to `denyTokens/BAS.json`.
- Reason: scam token that blocks transfers.

Made with [Cursor](https://cursor.com)