### PR TITLE
feat(tokens): add BOB token on Monad (chainId 143)

### DIFF
--- a/tokens/MON.json
+++ b/tokens/MON.json
@@ -134,5 +134,13 @@
     "symbol": "mHyperBTC",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/71550/standard/mhyperbtc-Bvh-K9IL.png"
-  }
+  },
+  {
+  "chainId": 143,
+  "address": "0x21E325B059Cd83d4037C82F0F5998Ba2dF3d7777",
+  "name": "Bob",
+  "symbol": "BOB",
+  "decimals": 18,
+  "logoURI": "https://assets.coingecko.com/coins/images/102173014/standard/main_mascot.png"
+}
 ]


### PR DESCRIPTION
Adds Bob (BOB) token metadata to LI.FI customized token list for Monad so BOB is searchable and displays with logo in LI.FI-powered UIs.

Token details:

Name: Bob
Symbol: BOB
Address: 0x21E325B059Cd83d4037C82F0F5998Ba2dF3d7777
Chain ID: 143 (Monad)
Decimals: 18
Logo URI: https://bobmonad.com/bass/bob.png
Project: https://bobmonad.com