### PR TITLE
feat: add Mento stable tokens on Celo and Monad

### DIFF
--- a/tokens/CEL.json
+++ b/tokens/CEL.json
@@ -14,5 +14,125 @@
     "decimals": 18,
     "name": "USDA",
     "logoURI": "https://raw.githubusercontent.com/AngleProtocol/angle-token-list/main/src/assets/tokens/USDA.svg"
+  },
+  {
+    "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
+    "chainId": 42220,
+    "symbol": "USDm",
+    "decimals": 18,
+    "name": "Mento Dollar",
+    "logoURI": "https://reserve.mento.org/tokens/USDm.svg"
+  },
+  {
+    "address": "0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73",
+    "chainId": 42220,
+    "symbol": "EURm",
+    "decimals": 18,
+    "name": "Mento Euro",
+    "logoURI": "https://reserve.mento.org/tokens/EURm.svg"
+  },
+  {
+    "address": "0xCCF663b1fF11028f0b19058d0f7B674004a40746",
+    "chainId": 42220,
+    "symbol": "GBPm",
+    "decimals": 18,
+    "name": "Mento British Pound",
+    "logoURI": "https://reserve.mento.org/tokens/GBPm.svg"
+  },
+  {
+    "address": "0xc45eCF20f3CD864B32D9794d6f76814aE8892e20",
+    "chainId": 42220,
+    "symbol": "JPYm",
+    "decimals": 18,
+    "name": "Mento Japanese Yen",
+    "logoURI": "https://reserve.mento.org/tokens/JPYm.svg"
+  },
+  {
+    "address": "0xb55a79F398E759E43C95b979163f30eC87Ee131D",
+    "chainId": 42220,
+    "symbol": "CHFm",
+    "decimals": 18,
+    "name": "Mento Swiss Franc",
+    "logoURI": "https://reserve.mento.org/tokens/CHFm.svg"
+  },
+  {
+    "address": "0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787",
+    "chainId": 42220,
+    "symbol": "BRLm",
+    "decimals": 18,
+    "name": "Mento Brazilian Real",
+    "logoURI": "https://reserve.mento.org/tokens/BRLm.svg"
+  },
+  {
+    "address": "0x73F93dcc49cB8A239e2032663e9475dd5ef29A08",
+    "chainId": 42220,
+    "symbol": "XOFm",
+    "decimals": 18,
+    "name": "Mento West African CFA Franc",
+    "logoURI": "https://reserve.mento.org/tokens/XOFm.svg"
+  },
+  {
+    "address": "0x456a3D042C0DbD3db53D5489e98dFb038553B0d0",
+    "chainId": 42220,
+    "symbol": "KESm",
+    "decimals": 18,
+    "name": "Mento Kenyan Shilling",
+    "logoURI": "https://reserve.mento.org/tokens/KESm.svg"
+  },
+  {
+    "address": "0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B",
+    "chainId": 42220,
+    "symbol": "PHPm",
+    "decimals": 18,
+    "name": "Mento Philippine Peso",
+    "logoURI": "https://reserve.mento.org/tokens/PHPm.svg"
+  },
+  {
+    "address": "0x8A567e2aE79CA692Bd748aB832081C45de4041eA",
+    "chainId": 42220,
+    "symbol": "COPm",
+    "decimals": 18,
+    "name": "Mento Colombian Peso",
+    "logoURI": "https://reserve.mento.org/tokens/COPm.svg"
+  },
+  {
+    "address": "0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313",
+    "chainId": 42220,
+    "symbol": "GHSm",
+    "decimals": 18,
+    "name": "Mento Ghanaian Cedi",
+    "logoURI": "https://reserve.mento.org/tokens/GHSm.svg"
+  },
+  {
+    "address": "0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6",
+    "chainId": 42220,
+    "symbol": "ZARm",
+    "decimals": 18,
+    "name": "Mento South African Rand",
+    "logoURI": "https://reserve.mento.org/tokens/ZARm.svg"
+  },
+  {
+    "address": "0xff4Ab19391af240c311c54200a492233052B6325",
+    "chainId": 42220,
+    "symbol": "CADm",
+    "decimals": 18,
+    "name": "Mento Canadian Dollar",
+    "logoURI": "https://reserve.mento.org/tokens/CADm.svg"
+  },
+  {
+    "address": "0x7175504C455076F15c04A2F90a8e352281F492F9",
+    "chainId": 42220,
+    "symbol": "AUDm",
+    "decimals": 18,
+    "name": "Mento Australian Dollar",
+    "logoURI": "https://reserve.mento.org/tokens/AUDm.svg"
+  },
+  {
+    "address": "0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71",
+    "chainId": 42220,
+    "symbol": "NGNm",
+    "decimals": 18,
+    "name": "Mento Nigerian Naira",
+    "logoURI": "https://reserve.mento.org/tokens/NGNm.svg"
   }
 ]

--- a/tokens/MON.json
+++ b/tokens/MON.json
@@ -134,5 +134,45 @@
     "symbol": "mHyperBTC",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/71550/standard/mhyperbtc-Bvh-K9IL.png"
+  },
+  {
+    "chainId": 143,
+    "address": "0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115",
+    "name": "Mento Dollar",
+    "symbol": "USDm",
+    "decimals": 18,
+    "logoURI": "https://reserve.mento.org/tokens/USDm.svg"
+  },
+  {
+    "chainId": 143,
+    "address": "0x4D502d735B4C574B487Ed641ae87cEaE884731C7",
+    "name": "Mento Euro",
+    "symbol": "EURm",
+    "decimals": 18,
+    "logoURI": "https://reserve.mento.org/tokens/EURm.svg"
+  },
+  {
+    "chainId": 143,
+    "address": "0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1",
+    "name": "Mento British Pound",
+    "symbol": "GBPm",
+    "decimals": 18,
+    "logoURI": "https://reserve.mento.org/tokens/GBPm.svg"
+  },
+  {
+    "chainId": 143,
+    "address": "0x22f6A6752800eAB67b84748FeFc3cC658384aF72",
+    "name": "Mento Japanese Yen",
+    "symbol": "JPYm",
+    "decimals": 18,
+    "logoURI": "https://reserve.mento.org/tokens/JPYm.svg"
+  },
+  {
+    "chainId": 143,
+    "address": "0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C",
+    "name": "Mento Swiss Franc",
+    "symbol": "CHFm",
+    "decimals": 18,
+    "logoURI": "https://reserve.mento.org/tokens/CHFm.svg"
   }
 ]


### PR DESCRIPTION
## Summary

Adds [Mento Protocol](https://mento.org) stable tokens to the LI.FI customized token list so they're routable through LI.FI / jumper.exchange. All entries use 18 decimals and serve logos from `https://reserve.mento.org/tokens/<SYMBOL>.svg`.

### Celo (chainId 42220) — 15 tokens
| Symbol | Address | Name |
|---|---|---|
| USDm | `0x765DE816845861e75A25fCA122bb6898B8B1282a` | Mento Dollar |
| EURm | `0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73` | Mento Euro |
| GBPm | `0xCCF663b1fF11028f0b19058d0f7B674004a40746` | Mento British Pound |
| JPYm | `0xc45eCF20f3CD864B32D9794d6f76814aE8892e20` | Mento Japanese Yen |
| CHFm | `0xb55a79F398E759E43C95b979163f30eC87Ee131D` | Mento Swiss Franc |
| BRLm | `0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787` | Mento Brazilian Real |
| XOFm | `0x73F93dcc49cB8A239e2032663e9475dd5ef29A08` | Mento West African CFA Franc |
| KESm | `0x456a3D042C0DbD3db53D5489e98dFb038553B0d0` | Mento Kenyan Shilling |
| PHPm | `0x105d4A9306D2E55a71d2Eb95B81553AE1dC20d7B` | Mento Philippine Peso |
| COPm | `0x8A567e2aE79CA692Bd748aB832081C45de4041eA` | Mento Colombian Peso |
| GHSm | `0xfAeA5F3404bbA20D3cc2f8C4B0A888F55a3c7313` | Mento Ghanaian Cedi |
| ZARm | `0x4c35853A3B4e647fD266f4de678dCc8fEC410BF6` | Mento South African Rand |
| CADm | `0xff4Ab19391af240c311c54200a492233052B6325` | Mento Canadian Dollar |
| AUDm | `0x7175504C455076F15c04A2F90a8e352281F492F9` | Mento Australian Dollar |
| NGNm | `0xE2702Bd97ee33c88c8f6f92DA3B733608aa76F71` | Mento Nigerian Naira |

### Monad mainnet (chainId 143) — 5 tokens
Bridged from Celo via Wormhole NTT.

| Symbol | Address | Name |
|---|---|---|
| USDm | `0xBC69212B8E4d445b2307C9D32dD68E2A4Df00115` | Mento Dollar |
| EURm | `0x4D502d735B4C574B487Ed641ae87cEaE884731C7` | Mento Euro |
| GBPm | `0x39bb4E0a204412bB98e821d25e7d955e69d40Fd1` | Mento British Pound |
| JPYm | `0x22f6A6752800eAB67b84748FeFc3cC658384aF72` | Mento Japanese Yen |
| CHFm | `0xF64e91fFEf7ef43aA314F0Bc2AC39f770797990C` | Mento Swiss Franc |

## Follow-ups

Polygon and Base entries will follow once their NTT bridges go live on mainnet.

## Test plan

- [x] `pnpm test` passes locally (1602 assertions, including address-checksum and schema validation for the new entries)
- [x] All `logoURI`s resolve to valid SVGs at `https://reserve.mento.org/tokens/<SYMBOL>.svg`
- [x] Addresses verified against on-chain deployments and the [Mento contracts package](https://github.com/mento-protocol/mento-deployments-v2)