### PR TITLE
feat: add Arena Two (ATWO) on Base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -576,12 +576,12 @@
     "logoURI": "https://yala.org/yu.svg"
   },
   {
-  "name": "Bio Protocol",
-  "address": "0x226A2FA2556C48245E57cd1cbA4C6c9e67077DD2",
-  "symbol": "BIO",
-  "chainId": 8453,
-  "decimals": 18,
-  "logoURI": "https://app.bio.xyz/logos/bio-logo.png"
+    "name": "Bio Protocol",
+    "address": "0x226A2FA2556C48245E57cd1cbA4C6c9e67077DD2",
+    "symbol": "BIO",
+    "chainId": 8453,
+    "decimals": 18,
+    "logoURI": "https://app.bio.xyz/logos/bio-logo.png"
   },
   {
     "name": "SEDA",
@@ -696,12 +696,12 @@
     "symbol": "apyUSD"
   },
   {
-      "name": "USDSM",
-      "address": "0x26C358F7c5fEdB20a6ddEf108cD91Efb6B8Da0Cb",
-      "symbol": "USDSM",
-      "decimals": 18,
-      "chainId": 8453,
-      "logoURI": "https://raw.githubusercontent.com/curvefi/curve-assets/refs/heads/main/images/assets-etherlink/0x6bde51212203ae5d592cc5180da2abbd41c922de.png"
+    "name": "USDSM",
+    "address": "0x26C358F7c5fEdB20a6ddEf108cD91Efb6B8Da0Cb",
+    "symbol": "USDSM",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://raw.githubusercontent.com/curvefi/curve-assets/refs/heads/main/images/assets-etherlink/0x6bde51212203ae5d592cc5180da2abbd41c922de.png"
   },
   {
     "name": "Coinbase Wrapped MEGA",
@@ -714,9 +714,17 @@
   {
     "address": "0x8B7DdE054BE9D180c1Be7FaE0874697374A49832",
     "chainId": 8453,
-    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg", 
+    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg",
     "decimals": 18,
     "name": "Wrapped PROS",
     "symbol": "PROS"
+  },
+  {
+    "name": "Arena Two",
+    "address": "0x499D35eBE6cEe9B2Ac35Fd003fcBbeeB9CFc7B32",
+    "symbol": "ATWO",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://arenatwo.com/token/atwo/logo-200.png"
   }
 ]


### PR DESCRIPTION
## Summary

Adds **Arena Two ($ATWO)** to `tokens/BAS.json` (Base mainnet, chainId 8453).

- **Contract:** `0x499D35eBE6cEe9B2Ac35Fd003fcBbeeB9CFc7B32` (Base, chainId 8453)
- **Symbol:** ATWO
- **Decimals:** 18
- **Logo:** `https://arenatwo.com/token/atwo/logo-200.png` (200×200 transparent PNG)

## Token information

Arena Two is a multi-sport entertainment platform on Base running a live World Series across eight global cities (6v6 indoor football, MMA, padel). ATWO is the native governance/utility token used for on-chain fan voting that influences live competitive outcomes, player trials, digital collectible drops, and token-gated event experiences.

## Verification

- **Contract on BaseScan (verified source):** https://basescan.org/token/0x499D35eBE6cEe9B2Ac35Fd003fcBbeeB9CFc7B32
- **CoinGecko (live):** https://www.coingecko.com/en/coins/arena-two
- **CoinMarketCap:** UCID 40006 — https://coinmarketcap.com/currencies/arena-two/
- **Audit:** Hacken, December 2025, 0 Critical / 0 High — https://hacken.io/audits/arena-two/

## USD pricing availability

USD price discovery via DeBank and Zerion is expected within 24-48h post-TGE (18 May 2026 12:00 UTC) once the Aerodrome on-chain liquidity pool (deployed by GSR Markets, $400K ATWO + $400K USDC, 90-day lock) is live and trading. If the PR cannot be reviewed until pricing flows, we're happy to wait — just wanted to be in the queue early.

## Files

- `tokens/BAS.json` — single entry appended.