### PR TITLE
chore(deny-tokens): deny scam WETH token on Solana (WEvsSb)

### DIFF
--- a/denyTokens/SOL.json
+++ b/denyTokens/SOL.json
@@ -23,5 +23,10 @@
     "chainId": 1151111081099710,
     "address": "G7rxkFy8hTEhtW2ZyV2xkhGFX3cxAKSsydY4E1crvTwG",
     "reason": "Scam token. Missleading token name"
+  },
+  {
+    "chainId": 1151111081099710,
+    "address": "WEvsSbEe8SmDsZQmmKv4FsHTNAqVgdNuaB1Sxc1JvH5",
+    "reason": "Scam WETH token with active freeze authority."
   }
 ]


### PR DESCRIPTION
## Summary

Deny-list fake WETH token on Solana that impersonates Wormhole WETH and locks user funds via freeze authority.

**Scam token:** `WEvsSbEe8SmDsZQmmKv4FsHTNAqVgdNuaB1Sxc1JvH5`

## Evidence

| | Real Wormhole WETH | Scam "WETH" |
|---|---|---|
| Mint | `7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs` | `WEvsSbEe8SmDsZQmmKv4FsHTNAqVgdNuaB1Sxc1JvH5` |
| Decimals | 8 | 6 |
| Freeze authority | None | Active (`BdD7ci...`) |
| Jupiter strict list | Yes | No |
| Mayan token list | Yes | No |

## Impact

- User ATA was frozen after receiving this token via a Mayan Swift route: https://solscan.io/account/a7mvjHgFZXDVEQHTevrA6xYAs1kE1XqbSsZyQEZGi6e
- 0.00497 "WETH" (~$9.77) permanently locked
- Only the freeze authority (`BdD7ciWxxvnC4hLvqwzzgaBbq5B6BVCChrDAz1dk4cxa`) can unfreeze — neither Mayan nor LI.FI can recover the funds

## Test plan

- [x] JSON valid
- [x] All 1590 tests pass

Made with [Cursor](https://cursor.com)