### PR TITLE
Add K9 and PUPCUP (World Pup Coin) to Ethereum tokens

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1026,7 +1026,7 @@
   {
     "address": "0xAFF2565091E7207191dBe340B8528D02FA78d044",
     "chainId": 1,
-    "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053", 
+    "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053",
     "decimals": 18,
     "name": "Asteroid",
     "symbol": "ASTEROID"
@@ -1034,9 +1034,25 @@
   {
     "address": "0xB197E02499e6502733C6bCE2eb39013C39A03147",
     "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg", 
+    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg",
     "decimals": 18,
     "name": "Wrapped PROS",
     "symbol": "PROS"
+  },
+  {
+    "name": "K9",
+    "address": "0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930",
+    "symbol": "K9",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930/logo.png"
+  },
+  {
+    "name": "World Pup Coin",
+    "address": "0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef",
+    "symbol": "PUPCUP",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef/logo.png"
   }
 ]


### PR DESCRIPTION
Adding K9 and PUPCUP (World Pup Coin) from the Clutch Puppies DeFi ecosystem on Ethereum mainnet.

**K9** — `0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930` | 0% tax | https://dex.clutch.market
**PUPCUP** — `0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef` | 0% tax | https://pupcup.clutch.market/

Active Uniswap V4 liquidity. GoPlus security: clean. Not mintable, no hidden owner.