### PR TITLE
feat: two-lane PR workflow (issue form + /add-token bot)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
-# All changes in this repo require approval from a member of one of these teams.
-# Members of either team can also self-approve and merge their own PRs once CI is green.
+# These teams own this repo. PRs from non-team members are blocked at
+# branch protection (CI is the merge gate; no second-approver required).
+# Listing the teams here also makes them the default review-request target
+# for any PR opened in the repo.
 
 * @lifinance/fullstack @lifinance/techsupport

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# All changes in this repo require approval from a member of one of these teams.
+# Members of either team can also self-approve and merge their own PRs once CI is green.
+
+* @lifinance/fullstack @lifinance/techsupport

--- a/.github/ISSUE_TEMPLATE/add-token.yml
+++ b/.github/ISSUE_TEMPLATE/add-token.yml
@@ -1,6 +1,6 @@
 name: Add a token to the customized token list
 description: Request a new token to be added to the LI.FI customized token list.
-title: "[token request] <chainId> <symbol>"
+title: "[token request]"
 labels: ["token-request"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/add-token.yml
+++ b/.github/ISSUE_TEMPLATE/add-token.yml
@@ -1,0 +1,103 @@
+name: Add a token to the customized token list
+description: Request a new token to be added to the LI.FI customized token list.
+title: "[token request] <chainId> <symbol>"
+labels: ["token-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! Fill in the fields below and an internal LI.FI team member will pick this up and turn it into a PR (typically within a few working days — we get a Slack notification the moment your issue is opened).
+
+        **All fields are required unless marked optional.** Incomplete submissions will be closed without action.
+
+        ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). If your chain isn't there yet, see the [README](https://github.com/lifinance/customized-token-list/blob/main/README.md#how-to-add-a-new-chain) — adding a new chain is a separate process and must be done by an internal team member.
+
+  - type: input
+    id: partner-org
+    attributes:
+      label: Partner / organization
+      description: Which company or project is this request from? (e.g. `Ledger`, `Phantom`, `community`).
+      placeholder: e.g. Ledger
+    validations:
+      required: true
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact email
+      description: How can we reach you if we have a question about this request?
+      placeholder: e.g. partnerships@example.com
+    validations:
+      required: true
+
+  - type: input
+    id: chainId
+    attributes:
+      label: Chain ID
+      description: |
+        The numeric chain ID (e.g. `1` for Ethereum, `42161` for Arbitrum, `8453` for Base, `137` for Polygon, `56` for BNB Smart Chain). You can find chain IDs at <https://chainlist.org> or in LI.FI's [`/chains` API endpoint](https://li.quest/v1/chains).
+      placeholder: e.g. 1
+    validations:
+      required: true
+
+  - type: input
+    id: address
+    attributes:
+      label: Token contract address
+      description: The deployed token contract address on the chain above. For EVM chains, use the checksummed address.
+      placeholder: e.g. 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+    validations:
+      required: true
+
+  - type: input
+    id: symbol
+    attributes:
+      label: Symbol
+      placeholder: e.g. USDC
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      placeholder: e.g. USD Coin
+    validations:
+      required: true
+
+  - type: input
+    id: decimals
+    attributes:
+      label: Decimals
+      placeholder: e.g. 6
+    validations:
+      required: true
+
+  - type: input
+    id: logoURI
+    attributes:
+      label: Logo URL
+      description: A publicly-reachable, permanent URL to the token logo (PNG or SVG, ideally 256x256 or larger, transparent background).
+      placeholder: e.g. https://example.com/logos/usdc.png
+    validations:
+      required: true
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: Why should this token be added? Link your project, Coingecko page, and socials so we can validate the token.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have searched existing issues and confirmed this token is not already requested or listed.
+          required: true
+        - label: The contract address above is correct and refers to a legitimate, non-malicious token.
+          required: true
+        - label: The logo URL is permanent (not a temporary or signed URL that will expire).
+          required: true

--- a/.github/ISSUE_TEMPLATE/add-token.yml
+++ b/.github/ISSUE_TEMPLATE/add-token.yml
@@ -10,7 +10,7 @@ body:
 
         **All fields are required unless marked optional.** Incomplete submissions will be closed without action.
 
-        ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). If your chain isn't there yet, see the [README](https://github.com/lifinance/customized-token-list/blob/main/README.md#how-to-add-a-new-chain) — adding a new chain is a separate process and must be done by an internal team member.
+        ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). **If your chain isn't there yet, please [contact LI.FI support](https://li.fi/support) instead** — adding a new chain requires an internal team member to set it up first, and support will route the request to the right people.
 
   - type: input
     id: partner-org

--- a/.github/ISSUE_TEMPLATE/add-token.yml
+++ b/.github/ISSUE_TEMPLATE/add-token.yml
@@ -10,7 +10,7 @@ body:
 
         **All fields are required unless marked optional.** Incomplete submissions will be closed without action.
 
-        ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). **If your chain isn't there yet, please [contact LI.FI support](https://li.fi/support) instead** — adding a new chain requires an internal team member to set it up first, and support will route the request to the right people.
+        ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). **If your chain isn't there yet, please [contact LI.FI support](https://help.li.fi/hc/en-us/requests/new) instead** — adding a new chain requires an internal team member to set it up first, and support will route the request to the right people.
 
   - type: input
     id: partner-org

--- a/.github/ISSUE_TEMPLATE/add-token.yml
+++ b/.github/ISSUE_TEMPLATE/add-token.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for contributing! Fill in the fields below and an internal LI.FI team member will pick this up and turn it into a PR (typically within a few working days — we get a Slack notification the moment your issue is opened).
 
-        **All fields are required unless marked optional.** Incomplete submissions will be closed without action.
+        **All fields are required.** Incomplete submissions will be closed without action.
 
         ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). **If your chain isn't there yet, please [contact LI.FI support](https://help.li.fi/hc/en-us/requests/new) instead** — adding a new chain requires an internal team member to set it up first, and support will route the request to the right people.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: LI.FI Support
-    url: https://li.fi/support
+    url: https://help.li.fi/hc/en-us/requests/new
     about: For general LI.FI questions unrelated to the customized token list, please use our support channels.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: LI.FI Support
+    url: https://li.fi/support
+    about: For general LI.FI questions unrelated to the customized token list, please use our support channels.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+  PRs are restricted to members of @lifinance/fullstack and @lifinance/techsupport.
+  External contributors: please open an issue using the "Add a token" template instead.
+  See README.md for the full process.
+-->
+
+## Summary
+
+<!-- One line: what is this PR adding / changing? -->
+
+## Source
+
+<!-- Required. Pick one and fill in the details. -->
+
+- [ ] **Internal request** — added by an internal team member (no upstream issue)
+- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`
+
+## Checklist
+
+- [ ] JSON validates (CI will confirm)
+- [ ] Logo URL is reachable and renders correctly
+- [ ] Token contract address is checksummed and verified on the relevant block explorer
+- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge

--- a/.github/scripts/apply-token.mjs
+++ b/.github/scripts/apply-token.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * apply-token.mjs — Applies a token submission to the right tokens/<KEY>.json file.
+ *
+ * Called by .github/workflows/add-token.yml.
+ *
+ * Inputs (via env vars, set by the workflow's "Parse issue body" step):
+ *   PAYLOAD — JSON string with fields: partner, contact, chainId, address,
+ *             symbol, name, decimals, logoURI, justification.
+ *
+ * Behaviour:
+ *   1. Scans tokens/*.json and builds a map of chainId → filename by reading
+ *      the first entry of each file. This makes the script self-updating: when
+ *      a new chain file is added to the repo, no script change is needed.
+ *   2. Looks up the partner-supplied chainId in that map.
+ *   3. Refuses if no file is found for that chainId (new chains must be added
+ *      manually first — see README §"How to add a new chain").
+ *   4. Refuses on duplicate address (case-insensitive).
+ *   5. Appends the new token as the last element (per the existing repo convention).
+ *   6. Writes the file back with 2-space indent + trailing newline.
+ *
+ * Exit codes:
+ *   0  success
+ *   1  validation failure — message in stderr, surfaced back to the issue
+ *      by the workflow.
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const TOKENS_DIR = resolve(REPO_ROOT, 'tokens');
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+function required(obj, key) {
+  const v = obj[key];
+  if (v === undefined || v === null || String(v).trim() === '') {
+    fail(`Missing required field: ${key}`);
+  }
+  return String(v).trim();
+}
+
+// ---------- 1. Parse payload ----------
+
+const payload = (() => {
+  try {
+    return JSON.parse(process.env.PAYLOAD ?? '{}');
+  } catch (e) {
+    fail(`PAYLOAD env var is not valid JSON: ${e.message}`);
+  }
+})();
+
+const chainIdRaw = required(payload, 'chainId');
+const chainId = Number(chainIdRaw);
+if (!Number.isInteger(chainId) || chainId <= 0) {
+  fail(`Chain ID must be a positive integer, got "${chainIdRaw}".`);
+}
+
+const address = required(payload, 'address');
+const symbol = required(payload, 'symbol');
+const name = required(payload, 'name');
+const decimalsRaw = required(payload, 'decimals');
+const logoURI = required(payload, 'logoURI');
+
+const decimals = Number(decimalsRaw);
+if (!Number.isInteger(decimals) || decimals < 0 || decimals > 36) {
+  fail(`Decimals must be a non-negative integer ≤ 36, got "${decimalsRaw}".`);
+}
+
+// ---------- 2. Build chainId → filename map by scanning tokens/ ----------
+
+if (!existsSync(TOKENS_DIR)) {
+  fail(`tokens/ directory not found at ${TOKENS_DIR} — repo layout has changed.`);
+}
+
+const chainIdToFile = new Map();
+for (const filename of readdirSync(TOKENS_DIR)) {
+  if (!filename.endsWith('.json')) continue;
+  const path = join(TOKENS_DIR, filename);
+  let list;
+  try {
+    list = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    console.warn(`⚠️  Skipping ${filename}: not valid JSON (${e.message})`);
+    continue;
+  }
+  if (!Array.isArray(list) || list.length === 0) continue;
+  const cid = list[0].chainId;
+  if (typeof cid !== 'number') continue;
+  if (chainIdToFile.has(cid)) {
+    // Defensive: shouldn't happen in this repo, but if it ever does we'd rather
+    // fail loudly than pick the wrong file silently.
+    fail(
+      `Two token files share chainId ${cid}: ${chainIdToFile.get(cid)} and ${filename}. ` +
+      `Resolve the ambiguity in the repo before retrying.`
+    );
+  }
+  chainIdToFile.set(cid, filename);
+}
+
+// ---------- 3. Resolve target file ----------
+
+const targetFilename = chainIdToFile.get(chainId);
+if (!targetFilename) {
+  const supported = [...chainIdToFile.keys()].sort((a, b) => a - b).join(', ');
+  fail(
+    `Chain ID ${chainId} is not supported in this repo yet (no matching file in tokens/).\n` +
+    `Supported chain IDs: ${supported}.\n` +
+    `See README §"How to add a new chain" — an internal team member needs to create ` +
+    `the chain file (and bump @lifi/types if needed) before tokens can be added.`
+  );
+}
+const targetPath = join(TOKENS_DIR, targetFilename);
+
+// ---------- 4. Validate address shape ----------
+
+// EVM addresses are universally 0x + 40 hex. Solana / Sui use different formats;
+// we identify those by the matching chain IDs in this repo.
+const NON_EVM_CHAIN_IDS = new Set([1151111081099710 /* SOL */, 9270000000000000 /* SUI */]);
+if (!NON_EVM_CHAIN_IDS.has(chainId) && !/^0x[a-fA-F0-9]{40}$/.test(address)) {
+  fail(`Address "${address}" does not look like a valid EVM address (0x + 40 hex chars).`);
+}
+
+// ---------- 5. Check duplicate, append, write ----------
+
+const list = JSON.parse(readFileSync(targetPath, 'utf8'));
+const existing = list.find((t) => String(t.address).toLowerCase() === address.toLowerCase());
+if (existing) {
+  fail(
+    `Token at address ${address} is already in tokens/${targetFilename} ` +
+    `(as "${existing.symbol}" / "${existing.name}"). Nothing to do.`
+  );
+}
+
+// Field order matches the README example.
+list.push({
+  address,
+  chainId,
+  logoURI,
+  decimals,
+  name,
+  symbol,
+});
+
+writeFileSync(targetPath, JSON.stringify(list, null, 2) + '\n');
+
+console.log(`✅ Appended ${symbol} (${address}) to tokens/${targetFilename} (chainId ${chainId}).`);

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -112,9 +112,35 @@ jobs:
             core.setOutput('chainId', payload.chainId);
 
       - name: Apply token to JSON
+        id: apply
+        continue-on-error: true
         env:
           PAYLOAD: ${{ steps.parse.outputs.payload }}
-        run: node .github/scripts/apply-token.mjs
+        run: node .github/scripts/apply-token.mjs 2>&1 | tee /tmp/apply-token.log
+
+      - name: Report apply failure back to issue
+        if: steps.apply.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          # Prefer the ❌-prefixed lines (script's user-facing messages); fall
+          # back to a generic pointer if none captured.
+          ERROR=$(grep '^❌' /tmp/apply-token.log | head -10 || true)
+          [ -z "$ERROR" ] && ERROR="Validation failed — see the workflow logs for details."
+          gh api -X POST "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='-1' || true
+          gh issue comment "${{ github.event.issue.number }}" --body "$(cat <<EOF
+          ❌ @${ACTOR} — \`/add-token\` failed to apply the change:
+
+          \`\`\`
+          ${ERROR}
+          \`\`\`
+
+          Please correct the issue body (edit the original issue) and re-run \`/add-token\`.
+          EOF
+          )"
+          exit 1
 
       - name: Create branch, commit, push, open PR
         id: pr

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -9,11 +9,12 @@
 #      branch protection — stops bogus runs early).
 #   3. React 👀 to acknowledge.
 #   4. Parse the Issue Form body into structured fields.
-#   5. Apply the token to the JSON list (see scripts/apply-token.mjs — TODO: fill in the actual
-#      mutation logic for this repo's schema).
-#   6. Open a PR on a fresh branch, crediting both the partner (from the issue) and the
+#   5. Apply the token to the JSON list via scripts/apply-token.mjs (looks up the right
+#      tokens/<KEY>.json by chainId, validates, refuses on duplicate/unknown chain, appends).
+#   6. If the apply step fails, post the validation error back to the issue and stop.
+#   7. Open a PR on a fresh branch, crediting both the partner (from the issue) and the
 #      internal who triggered the command.
-#   7. React ✅ and post a reply linking the PR.
+#   8. React ✅ and post a reply linking the PR.
 
 name: /add-token
 

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -14,7 +14,7 @@
 #   6. If the apply step fails, post the validation error back to the issue and stop.
 #   7. Open a PR on a fresh branch, crediting both the partner (from the issue) and the
 #      internal who triggered the command.
-#   8. React ✅ and post a reply linking the PR.
+#   8. React 🚀 and post a reply linking the PR.
 
 name: /add-token
 
@@ -54,10 +54,13 @@ jobs:
             fi
           done
           echo "❌ $ACTOR is not a member of fullstack or techsupport. Ignoring command."
-          # React with a 👎 so the commenter knows it was seen but rejected.
+          # React with a 👎 so the commenter knows the command was seen and rejected.
           gh api -X POST "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content='-1' || true
-          exit 78  # neutral skip, no red X on the action
+          # exit 0 so the run shows green: the unauthorised case is the system
+          # behaving as designed, not a failure. The 👎 reaction is the user-
+          # visible signal.
+          exit 0
 
       - name: React 👀 to comment
         env:

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -127,7 +127,14 @@ jobs:
           CHAIN_ID: ${{ steps.parse.outputs.chainId }}
         run: |
           set -e
-          BRANCH="add-token/issue-${ISSUE_NUM}-${SYMBOL,,}"
+          # Sanitize SYMBOL for use in the git branch name: lowercase, replace
+          # any non-alphanumeric chars with dashes, collapse repeats, trim ends.
+          # Falls back to "token" if the result is empty. SYMBOL itself is left
+          # unmodified for the commit message, PR title, and PR body (those
+          # contexts handle arbitrary strings safely).
+          SAFE_SYMBOL=$(printf '%s' "${SYMBOL,,}" | tr -cs '[:alnum:]' '-' | sed -E 's/^-+|-+$//g')
+          [ -z "$SAFE_SYMBOL" ] && SAFE_SYMBOL=token
+          BRANCH="add-token/issue-${ISSUE_NUM}-${SAFE_SYMBOL}"
           git config user.name "lifi-customizedtokenlist-bot[bot]"
           git config user.email "lifi-customizedtokenlist-bot[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -1,0 +1,173 @@
+# /add-token — Issue-to-PR converter
+#
+# Triggered when a member of @lifinance/fullstack or @lifinance/techsupport
+# comments `/add-token` on an issue created from the "Add a token" template.
+#
+# Flow:
+#   1. Mint a short-lived installation token from the lifi-customizedtokenlist-bot GitHub App.
+#   2. Verify the commenter is in one of the two authorized teams (defence in depth on top of
+#      branch protection — stops bogus runs early).
+#   3. React 👀 to acknowledge.
+#   4. Parse the Issue Form body into structured fields.
+#   5. Apply the token to the JSON list (see scripts/apply-token.mjs — TODO: fill in the actual
+#      mutation logic for this repo's schema).
+#   6. Open a PR on a fresh branch, crediting both the partner (from the issue) and the
+#      internal who triggered the command.
+#   7. React ✅ and post a reply linking the PR.
+
+name: /add-token
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}  # all access comes from the App token
+
+jobs:
+  add-token:
+    # Skip unless it's an issue comment (not a PR comment) starting with /add-token
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/add-token')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TOKENLIST_BOT_APP_ID }}
+          private-key: ${{ secrets.TOKENLIST_BOT_PRIVATE_KEY }}
+
+      - name: Verify commenter is in fullstack or techsupport
+        id: gate
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -e
+          for team in fullstack techsupport; do
+            if gh api "/orgs/lifinance/teams/$team/memberships/$ACTOR" --silent 2>/dev/null; then
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              echo "✅ $ACTOR is in @lifinance/$team"
+              exit 0
+            fi
+          done
+          echo "❌ $ACTOR is not a member of fullstack or techsupport. Ignoring command."
+          # React with a 👎 so the commenter knows it was seen but rejected.
+          gh api -X POST "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='-1' || true
+          exit 78  # neutral skip, no red X on the action
+
+      - name: React 👀 to comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api -X POST "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='eyes'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Parse issue body
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            // Issue Forms render each field as:  ### <Label>\n\n<value>\n\n
+            // (or _No response_ for empty optional fields)
+            const fields = {};
+            const re = /^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n###\s+|\n*$)/gm;
+            let m;
+            while ((m = re.exec(body)) !== null) {
+              fields[m[1].trim()] = m[2].trim();
+            }
+            const get = (label) => {
+              const v = fields[label];
+              if (!v || v === '_No response_') return '';
+              return v;
+            };
+            const payload = {
+              partner: get('Partner / organization'),
+              contact: get('Contact email'),
+              chainId: get('Chain ID'),
+              address: get('Token contract address'),
+              symbol: get('Symbol'),
+              name: get('Name'),
+              decimals: get('Decimals'),
+              logoURI: get('Logo URL'),
+              justification: get('Justification'),
+            };
+            core.setOutput('payload', JSON.stringify(payload));
+            core.setOutput('partner', payload.partner);
+            core.setOutput('symbol', payload.symbol);
+            core.setOutput('chainId', payload.chainId);
+
+      - name: Apply token to JSON
+        env:
+          PAYLOAD: ${{ steps.parse.outputs.payload }}
+        run: node .github/scripts/apply-token.mjs
+
+      - name: Create branch, commit, push, open PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.event.comment.user.login }}
+          PARTNER: ${{ steps.parse.outputs.partner }}
+          SYMBOL: ${{ steps.parse.outputs.symbol }}
+          CHAIN_ID: ${{ steps.parse.outputs.chainId }}
+        run: |
+          set -e
+          BRANCH="add-token/issue-${ISSUE_NUM}-${SYMBOL,,}"
+          git config user.name "lifi-customizedtokenlist-bot[bot]"
+          git config user.email "lifi-customizedtokenlist-bot[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "feat: add ${SYMBOL} on chain ${CHAIN_ID} (closes #${ISSUE_NUM})
+
+          Partner: ${PARTNER}
+          Triggered-by: @${ACTOR}"
+          git push origin "$BRANCH"
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Add ${SYMBOL} on chain ${CHAIN_ID} (partner: ${PARTNER})" \
+            --body "$(cat <<EOF
+          Closes #${ISSUE_NUM}.
+
+          ## Source
+          - **Partner / external request** — fulfils issue #${ISSUE_NUM}, partner: \`${PARTNER}\`
+          - **Triggered by:** @${ACTOR}
+
+          ## Checklist
+          - [ ] JSON validates (CI will confirm)
+          - [ ] Logo URL is reachable and renders correctly
+          - [ ] Token contract address is checksummed and verified on the relevant block explorer
+
+          ---
+          🤖 Auto-generated by \`/add-token\` from issue #${ISSUE_NUM}. Review the diff before merging.
+          EOF
+          )" \
+            --assignee "${ACTOR}")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: React ✅ and reply with PR link
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          gh api -X POST "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='rocket'
+          gh issue comment "${{ github.event.issue.number }}" \
+            --body "✅ PR opened by @${ACTOR}: ${PR_URL}. CI will run on the PR; merge there once it passes."

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Mint App installation token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.9.3
         with:
           app-id: ${{ secrets.TOKENLIST_BOT_APP_ID }}
           private-key: ${{ secrets.TOKENLIST_BOT_PRIVATE_KEY }}
@@ -66,19 +66,19 @@ jobs:
             -f content='eyes'
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
       - name: Parse issue body
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const body = context.payload.issue.body || '';

--- a/.github/workflows/close-fork-prs.yml
+++ b/.github/workflows/close-fork-prs.yml
@@ -1,0 +1,39 @@
+# close-fork-prs — Auto-closes any PR opened from a fork
+#
+# External contributions are intentionally not accepted as PRs — partners are
+# directed to the "Add a token" issue template instead (see README.md).
+# This workflow is the enforcement net: it closes any fork-PR immediately with
+# a friendly explanation linking the right path.
+#
+# PRs from internal branches (same repo) are unaffected.
+
+name: Close PRs from forks
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write  # required to post a comment on the PR
+
+jobs:
+  close-if-fork:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          gh pr comment "$PR_URL" --body "$(cat <<EOF
+          Hi @${AUTHOR} — thanks for contributing! 🙏
+
+          We don't accept pull requests from forks on this repo. Instead, please open an issue using the **[Add a token](../../issues/new?template=add-token.yml)** template. An internal LI.FI team member will pick it up and turn it into a PR within a few working days.
+
+          Closing this PR for now. See the [README](../../blob/main/README.md) for the full process.
+          EOF
+          )"
+          gh pr close "$PR_URL"

--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -1,0 +1,38 @@
+# issue-slack-notify — Pings #dev-backend-expansion-review on every new issue
+#
+# Purpose: make sure new token requests don't sit unnoticed. The whole point of
+# the issue-based external flow is that an internal picks it up fast.
+#
+# Only fires on `opened` (not edits / labels / comments) to avoid noise.
+
+name: Notify Slack on new issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "🆕 New token-list issue: <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }} — ${{ github.event.issue.title }}>",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🆕 *New token-list issue* <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }}>\n*${{ github.event.issue.title }}*\nOpened by `${{ github.event.issue.user.login }}` — a member of `@lifinance/fullstack` or `@lifinance/techsupport` can convert it to a PR by commenting `/add-token` on the issue."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -23,15 +23,19 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW }}
           webhook-type: incoming-webhook
+          # User-controlled values (issue title, user login) are wrapped in
+          # toJSON() via the format() helper to ensure any embedded quotes,
+          # backslashes, or newlines are safely escaped and can't break the
+          # JSON payload structure.
           payload: |
             {
-              "text": "🆕 New token-list issue: <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }} — ${{ github.event.issue.title }}>",
+              "text": ${{ toJSON(format('🆕 New token-list issue: <{0}|#{1} — {2}>', github.event.issue.html_url, github.event.issue.number, github.event.issue.title)) }},
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "🆕 *New token-list issue* <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }}>\n*${{ github.event.issue.title }}*\nOpened by `${{ github.event.issue.user.login }}` — a member of `@lifinance/fullstack` or `@lifinance/techsupport` can convert it to a PR by commenting `/add-token` on the issue."
+                    "text": ${{ toJSON(format('🆕 *New token-list issue* <{0}|#{1}>\n*{2}*\nOpened by `{3}` — a member of `@lifinance/fullstack` or `@lifinance/techsupport` can convert it to a PR by commenting `/add-token` on the issue.', github.event.issue.html_url, github.event.issue.number, github.event.issue.title, github.event.issue.user.login)) }}
                   }
                 }
               ]

--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -1,41 +1,115 @@
-# issue-slack-notify — Pings #dev-backend-expansion-review on every new issue
+# on-new-issue — Token-request issue housekeeping + Slack notification.
 #
-# Purpose: make sure new token requests don't sit unnoticed. The whole point of
-# the issue-based external flow is that an internal picks it up fast.
+# Triggers when a new issue is opened. For issues created from the "Add a token"
+# template (label: token-request) it:
+#   1. Parses the structured form body.
+#   2. Rewrites the title from "[token request] <chainId> <symbol>" placeholder
+#      to "[token request] chain <real-id> <real-symbol>" so the issues list,
+#      search, and Slack notification all show real data instead of literal
+#      angle-bracket placeholders.
+#   3. Posts a Slack ping to #dev-backend-expansion-review with the resolved
+#      title so internals can pick it up fast.
 #
-# Only fires on `opened` (not edits / labels / comments) to avoid noise.
+# For non-token-request issues, only the Slack ping fires (with the original
+# title untouched).
+#
+# Only fires on `opened` (not edits / labels / comments) to avoid noise and to
+# guarantee no self-trigger loop from the title edit.
 
-name: Notify Slack on new issue
+name: On new issue
 
 on:
   issues:
     types: [opened]
 
+# Most steps run under the App installation token (which scopes its own
+# permissions); the workflow-level GITHUB_TOKEN is unused for mutations.
 permissions:
   issues: read
 
 jobs:
-  notify:
+  process:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.9.3
+        with:
+          app-id: ${{ secrets.TOKENLIST_BOT_APP_ID }}
+          private-key: ${{ secrets.TOKENLIST_BOT_PRIVATE_KEY }}
+
+      - name: Parse form fields and rewrite title
+        id: parse
+        if: contains(github.event.issue.labels.*.name, 'token-request')
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            // Same field-extraction pattern as .github/workflows/add-token.yml.
+            // Issue Forms render each field as: ### <Label>\n\n<value>\n\n
+            const body = context.payload.issue.body || '';
+            const fields = {};
+            const re = /^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n###\s+|\n*$)/gm;
+            let m;
+            while ((m = re.exec(body)) !== null) {
+              fields[m[1].trim()] = m[2].trim();
+            }
+            const get = (label) => {
+              const v = fields[label];
+              if (!v || v === '_No response_') return '';
+              return v;
+            };
+
+            const chainId = get('Chain ID');
+            const symbol = get('Symbol');
+            core.setOutput('chainId', chainId);
+            core.setOutput('symbol', symbol);
+
+            // If we couldn't extract both fields, leave the title alone — the
+            // /add-token bot's validation will surface the missing-fields error
+            // back to the issue on the first run.
+            if (!chainId || !symbol) {
+              core.warning(`Could not parse chainId="${chainId}" symbol="${symbol}" from issue body; leaving title unchanged.`);
+              core.setOutput('title', context.payload.issue.title);
+              return;
+            }
+
+            const newTitle = `[token request] chain ${chainId} ${symbol}`;
+            if (newTitle === context.payload.issue.title) {
+              core.info(`Title is already "${newTitle}"; no rewrite needed.`);
+              core.setOutput('title', newTitle);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              title: newTitle,
+            });
+            core.info(`Rewrote issue #${context.payload.issue.number} title to "${newTitle}".`);
+            core.setOutput('title', newTitle);
+
       - name: Post to Slack
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW }}
           webhook-type: incoming-webhook
-          # User-controlled values (issue title, user login) are wrapped in
-          # toJSON() via the format() helper to ensure any embedded quotes,
-          # backslashes, or newlines are safely escaped and can't break the
-          # JSON payload structure.
+          # Use the rewritten title from the parse step when available; fall
+          # back to the original title (non-token-request issues, or parse
+          # failures).
+          # User-controlled values are wrapped in toJSON(format()) so any
+          # embedded quotes, backslashes, or newlines are safely escaped and
+          # can't break the JSON payload structure.
           payload: |
             {
-              "text": ${{ toJSON(format('🆕 New token-list issue: <{0}|#{1} — {2}>', github.event.issue.html_url, github.event.issue.number, github.event.issue.title)) }},
+              "text": ${{ toJSON(format('🆕 New token-list issue: <{0}|#{1} — {2}>', github.event.issue.html_url, github.event.issue.number, steps.parse.outputs.title || github.event.issue.title)) }},
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ${{ toJSON(format('🆕 *New token-list issue* <{0}|#{1}>\n*{2}*\nOpened by `{3}` — a member of `@lifinance/fullstack` or `@lifinance/techsupport` can convert it to a PR by commenting `/add-token` on the issue.', github.event.issue.html_url, github.event.issue.number, github.event.issue.title, github.event.issue.user.login)) }}
+                    "text": ${{ toJSON(format('🆕 *New token-list issue* <{0}|#{1}>\n*{2}*\nOpened by `{3}` — a member of `@lifinance/fullstack` or `@lifinance/techsupport` can convert it to a PR by commenting `/add-token` on the issue.', github.event.issue.html_url, github.event.issue.number, steps.parse.outputs.title || github.event.issue.title, github.event.issue.user.login)) }}
                   }
                 }
               ]

--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW }}
           webhook-type: incoming-webhook

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+The full contribution process — for both external partners and internal LI.FI team members — is documented in the **[README](README.md#-how-to-request-a-token)**.
+
+**Quick links:**
+
+- **External contributors:** [Open an "Add a token" issue](../../issues/new?template=add-token.yml). Do not open PRs from forks — they will be auto-closed.
+- **Internal team members** (`@lifinance/fullstack` or `@lifinance/techsupport`): open a PR directly for internal-originated changes, or comment `/add-token` on an external issue to convert it into a PR.
+
+See the [README](README.md) for the full rationale, the two-lane model, and how the `/add-token` automation works.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ And if we can validate the token:
 - we can find USD prices via Debank or Zerion APIs
 - the token is not a spam/fee-taking token
 
-You can also block scam tokens for a given chain by adding them to [`/denyTokens/<CHAIN_KEY>.json`](./denyTokens) — see [How to block a token](#how-to-block-a-token) below.
+You can also block scam tokens for a given chain by adding them to [`/denyTokens/<CHAIN_KEY>.json`](./denyTokens) — see [How to block a token](#how-to-block-a-token) below (internal team only; external partners should [contact LI.FI support](https://help.li.fi/hc/en-us/requests/new)).
 
 ---
 
@@ -59,10 +59,10 @@ The bot **never merges** — a human always pulls the trigger.
 
 | Path | Purpose |
 |---|---|
-| [`tokens/<KEY>.json`](./tokens) | One file per supported chain, containing a JSON array of `{address, chainId, logoURI, decimals, name, symbol}` entries. The filename uses LI.FI's internal chain key; the canonical identifier inside each entry is `chainId`. |
-| [`denyTokens/<KEY>.json`](./denyTokens) | Blocked tokens (scams, etc.) per chain. |
-| [`approvalResetTokens/<KEY>.json`](./approvalResetTokens) | Legacy ERC-20 tokens that require an approval reset before setting a new allowance (e.g. USDT on Ethereum). |
-| [`schema/`](./schema) | JSON schemas that `pnpm run test` validates each file against. |
+| [`tokens/<CHAIN_KEY>.json`](./tokens) | One file per supported chain, containing a JSON array of `{address, chainId, logoURI, decimals, name, symbol}` entries. The filename uses LI.FI's internal chain key; the canonical identifier inside each entry is `chainId`. |
+| [`denyTokens/<CHAIN_KEY>.json`](./denyTokens) | Blocked tokens (scams, etc.) per chain. |
+| [`approvalResetTokens/<CHAIN_KEY>.json`](./approvalResetTokens) | Legacy ERC-20 tokens that require an approval reset before setting a new allowance (e.g. USDT on Ethereum). |
+| [`schema/`](./schema) | JSON schemas defining the expected structure of each entry type. |
 | [`.github/ISSUE_TEMPLATE/add-token.yml`](./.github/ISSUE_TEMPLATE/add-token.yml) | The structured form external contributors fill in. |
 | [`.github/workflows/add-token.yml`](./.github/workflows/add-token.yml) | The `/add-token` issue-to-PR converter. |
 
@@ -70,7 +70,11 @@ Chain IDs (the canonical numeric identifier inside each entry, and what the issu
 
 ---
 
-## How to add a new chain
+## 👥 For internal team members
+
+> The sections below are for members of `@lifinance/fullstack` or `@lifinance/techsupport`. External contributors should use the [issue form](#-external-contributors-partners-projects-community) — these manual paths require write access to the repo.
+
+### How to add a new chain
 
 We add tokens based on chains. You can find all supported chains via our API endpoint [`/chains`](https://li.quest/v1/chains).
 
@@ -78,13 +82,13 @@ The format of the file for a new chain is `[ChainKey].json` and you can find the
 
 At the same time, please ensure the package [`@lifi/types`](https://github.com/lifinance/types) is the latest version, otherwise you cannot pass the test.
 
-Adding a new chain is an **internal-only** task (the `/add-token` automation refuses to act on chains that don't yet have a file) — open a PR directly that adds `tokens/<NEW_KEY>.json` with at least one entry, then partners can request tokens for that chain via the issue form.
+The `/add-token` automation refuses to act on chains that don't yet have a file, so this is the prerequisite step for accepting any token request on a new chain. Open a PR directly that adds `tokens/<NEW_CHAIN_KEY>.json` with at least one entry, then partners can request tokens for that chain via the issue form.
 
-## How to add your token (manual fallback)
+### How to add a token manually (instead of via `/add-token`)
 
-The recommended path is to use the [issue form](../../issues/new?template=add-token.yml). For an internal team member who'd rather edit the file by hand:
+The recommended path for any token request is to drive it through the [issue form](../../issues/new?template=add-token.yml) + `/add-token` automation — it keeps attribution clean and handles validation. Edit the file directly only when the automation doesn't fit (e.g. a one-off internal cleanup):
 
-Open `tokens/<CHAIN_KEY>.json`. Add your token as the last element in the list (don't forget the `,` after the previous token):
+Open `tokens/<CHAIN_KEY>.json`. Add the token as the last element in the list (don't forget the `,` after the previous token):
 
 ```json
   },
@@ -99,7 +103,7 @@ Open `tokens/<CHAIN_KEY>.json`. Add your token as the last element in the list (
 ]
 ```
 
-## How to block a token
+### How to block a token
 
 To block a scam token, find the file for the chain in the [`denyTokens/`](./denyTokens) folder.
 
@@ -117,7 +121,7 @@ Add the token as the last element in the list (don't forget the `,` after the pr
 
 Create a PR describing why we should block this token. Link the project, Coingecko page, and any supporting evidence.
 
-## How to report EVM tokens requiring an approval reset
+### How to report EVM tokens requiring an approval reset
 
 These lists of ERC-20 tokens help report the need for an initial approval reset transaction prior to setting a new allowance to the spender. Only a few legacy tokens are concerned (e.g. USDT on Ethereum mainnet).
 
@@ -132,4 +136,4 @@ When querying available token-swapping routes or quotes, if the source token is 
 - The bot is a GitHub App named `lifi-customizedtokenlist-bot`, installed on this repo only.
 - It has the minimum permissions needed: read/write on contents, issues, and pull requests; read on org members (to check team membership).
 - It does **not** receive webhooks and has **no** OAuth user-authentication flow — it only mints short-lived installation tokens inside Actions workflows.
-- Branch protection on `main` is configured to only allow pushes from `@lifinance/fullstack`, `@lifinance/techsupport`, and the bot.
+- Branch protection on `main` restricts pushes to `@lifinance/fullstack`, `@lifinance/techsupport`, and the bot. If this isn't yet enforced on a fresh repo, see Settings → Branches.

--- a/README.md
+++ b/README.md
@@ -137,3 +137,9 @@ When querying available token-swapping routes or quotes, if the source token is 
 - It has the minimum permissions needed: read/write on contents, issues, and pull requests; read on org members (to check team membership).
 - It does **not** receive webhooks and has **no** OAuth user-authentication flow — it only mints short-lived installation tokens inside Actions workflows.
 - Branch protection on `main` restricts pushes to `@lifinance/fullstack`, `@lifinance/techsupport`, and the bot. If this isn't yet enforced on a fresh repo, see Settings → Branches.
+
+---
+
+## 📌 Known limitations
+
+See [`TODO.md`](./TODO.md) for tracked v1 simplifications and follow-up work (currently: non-EVM address validation is hardcoded to Solana and Sui).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 LI.FI supports any token passed to the API as long as we can validate it and find a USD price for it.
 
-The API exposes a list of tokens that UIs can use as default to give their users tokens to choose from, e.g. our widget uses that list: https://li.quest/v1/tokens
+The API exposes a list of tokens that UIs can use as default to give their users tokens to choose from — for example, our widget uses that list at <https://li.quest/v1/tokens>.
 
 We automatically include tokens in that token list if they are listed in one of the token lists we support:
 
@@ -15,58 +15,121 @@ And if we can validate the token:
 - we can find USD prices via Debank or Zerion APIs
 - the token is not a spam/fee-taking token
 
-You can also add scam tokens to a blockchain network list in [`/denyTokens/NETX.json`](./denyTokens) and we will block this token in our system.
+You can also block scam tokens for a given chain by adding them to [`/denyTokens/<CHAIN_KEY>.json`](./denyTokens) — see [How to block a token](#how-to-block-a-token) below.
+
+---
+
+## 🚀 How to request a token
+
+We use a **two-lane model** to balance ease-of-submission for external partners with low overhead for the internal team.
+
+### 👤 External contributors (partners, projects, community)
+
+👉 **[Open a new "Add a token" issue](../../issues/new?template=add-token.yml)** and fill in all required fields.
+
+The moment your issue is opened, an internal LI.FI team member is pinged on Slack. They will turn it into a pull request (typically within a few working days) and merge it once CI passes.
+
+> ⚠️ **Do not open pull requests from forks.** Fork PRs are auto-closed by a workflow with a pointer back to the issue template. The issue template captures everything we need and is a faster path to merge.
+
+### 🛠️ Internal team members (`@lifinance/fullstack` or `@lifinance/techsupport`)
+
+You have two ways to add a token, depending on where the request came from:
+
+1. **Internal-originated change** — open a PR directly, wait for CI to pass, and self-merge. No second approver required.
+2. **External-originated request** — find the open issue and comment `/add-token` on it. A bot (`lifi-customizedtokenlist-bot`) will parse the issue, open a fully-populated PR, assign it to you, and link it back in the issue. Review the diff, wait for CI, self-merge.
+
+---
+
+## 🔁 How the `/add-token` automation works
+
+When an authorised internal comments `/add-token` on an issue created from the [Add a token](../../issues/new?template=add-token.yml) template, the [`add-token` workflow](./.github/workflows/add-token.yml) runs:
+
+1. A GitHub App (`lifi-customizedtokenlist-bot`) mints a short-lived installation token.
+2. The workflow verifies the commenter is a member of `@lifinance/fullstack` or `@lifinance/techsupport`. Non-members get a 👎 reaction; nothing else happens.
+3. The bot parses the structured fields from the issue body.
+4. [`scripts/apply-token.mjs`](./.github/scripts/apply-token.mjs) scans `tokens/*.json` to build a `chainId → filename` map (so it's always in sync with the repo — no hard-coded chain table to maintain), looks up the partner-supplied chain ID, and appends the new token to the matching file. Refuses on duplicate addresses or unsupported chain IDs.
+5. The bot opens a branch, commits, pushes, and opens a PR — all in the bot's identity, never using your personal credentials. The partner and your handle are credited in the PR body and commit trailer.
+6. The PR is assigned to you. CI runs ([`lint.yml`](./.github/workflows/lint.yml) + [`validate.yml`](./.github/workflows/validate.yml)). Once green, you merge — and merging closes the originating issue automatically (`Closes #<n>` in the PR body).
+
+The bot **never merges** — a human always pulls the trigger.
+
+---
+
+## 📦 What lives in this repo
+
+| Path | Purpose |
+|---|---|
+| [`tokens/<KEY>.json`](./tokens) | One file per supported chain, containing a JSON array of `{address, chainId, logoURI, decimals, name, symbol}` entries. The filename uses LI.FI's internal chain key; the canonical identifier inside each entry is `chainId`. |
+| [`denyTokens/<KEY>.json`](./denyTokens) | Blocked tokens (scams, etc.) per chain. |
+| [`approvalResetTokens/<KEY>.json`](./approvalResetTokens) | Legacy ERC-20 tokens that require an approval reset before setting a new allowance (e.g. USDT on Ethereum). |
+| [`schema/`](./schema) | JSON schemas that `pnpm run test` validates each file against. |
+| [`.github/ISSUE_TEMPLATE/add-token.yml`](./.github/ISSUE_TEMPLATE/add-token.yml) | The structured form external contributors fill in. |
+| [`.github/workflows/add-token.yml`](./.github/workflows/add-token.yml) | The `/add-token` issue-to-PR converter. |
+
+Chain IDs (the canonical numeric identifier inside each entry, and what the issue form asks partners for) can be looked up at <https://chainlist.org> or via LI.FI's [`/chains` API](https://li.quest/v1/chains). The 3-letter filename keys (`ETH`, `ARB`, `BAS`, …) are LI.FI's internal convention; partners never need to know them.
+
+---
 
 ## How to add a new chain
 
-We add tokens based on chains. You can find all supported chains through our API endpoint [/chains](https://li.quest/v1/chains).
+We add tokens based on chains. You can find all supported chains via our API endpoint [`/chains`](https://li.quest/v1/chains).
 
-The format of file of a new chain should be `[ChainKey].json` and you can find ChainKey [in our chains documentation](https://docs.li.fi/introduction/chains).
+The format of the file for a new chain is `[ChainKey].json` and you can find the ChainKey [in our chains documentation](https://docs.li.fi/introduction/chains).
 
-At the same time, please ensure the package `@lifi/types` is the latest version, otherwise you cannot pass the test. You can find it in [this repository](https://github.com/lifinance/types).
+At the same time, please ensure the package [`@lifi/types`](https://github.com/lifinance/types) is the latest version, otherwise you cannot pass the test.
 
-## How to add your token
+Adding a new chain is an **internal-only** task (the `/add-token` automation refuses to act on chains that don't yet have a file) — open a PR directly that adds `tokens/<NEW_KEY>.json` with at least one entry, then partners can request tokens for that chain via the issue form.
 
-To add your token find the file representing the chain your token is in in the **tokens** folder.
+## How to add your token (manual fallback)
 
-Add your token as the last element in the list (don't forget the `,` after the previous token):
+The recommended path is to use the [issue form](../../issues/new?template=add-token.yml). For an internal team member who'd rather edit the file by hand:
+
+Open `tokens/<CHAIN_KEY>.json`. Add your token as the last element in the list (don't forget the `,` after the previous token):
 
 ```json
-  },  <== Add the comma
+  },
   {
     "address": "0x155f0DD04424939368972f4e1838687d6a831151",
     "chainId": 42161,
-    "logoURI": "https://yoursite.com/token.svg", <= permanent link to an image of your token
+    "logoURI": "https://yoursite.com/token.svg",
     "decimals": 18,
     "name": "Nice Name",
     "symbol": "SYMBOL"
   }
 ]
-
 ```
 
 ## How to block a token
 
-To add a scam token find the file representing the chain the token is in in the **denyTokens** folder. 
+To block a scam token, find the file for the chain in the [`denyTokens/`](./denyTokens) folder.
 
 Add the token as the last element in the list (don't forget the `,` after the previous token):
 
 ```json
-  },  <== Add the comma
+  },
   {
     "address": "0xde3a24028580884448a5397872046a019649b084",
     "chainId": 43114,
-    "reason": "Deprecated USDT token on AVA", <= add an optional reason why the token should be blocked
+    "reason": "Deprecated USDT token on AVA"
   }
 ]
 ```
 
-Create a PR with the change describing why we should add that token. Link your project, CoinGecko and profiles so we can validate the token.
+Create a PR describing why we should block this token. Link the project, Coingecko page, and any supporting evidence.
 
 ## How to report EVM tokens requiring an approval reset
 
-Those lists of ERC-20 tokens help in reporting the need for an initial approval reset transaction prior to setting a new allowance to the spender. Only few legacy tokens are concerned, e.g. USDT on Ethereum mainnet.
+These lists of ERC-20 tokens help report the need for an initial approval reset transaction prior to setting a new allowance to the spender. Only a few legacy tokens are concerned (e.g. USDT on Ethereum mainnet).
 
-To add a legacy token on any of our supported EVM chain, you can create a PR with the token address and chainId reported in corresponding blockchain network file, e.g. [./approvalResetTokens/ETH.json](./approvalResetTokens/ETH.json).
+To add a legacy token on any supported EVM chain, create a PR with the token address and chainId added to the corresponding chain file, e.g. [`./approvalResetTokens/ETH.json`](./approvalResetTokens/ETH.json).
 
-When querying available token swapping routes or quotes, if the source token is in the approval reset list, the need for an approval reset transaction will be indicated via an optional field `approvalReset` in responses' dataset `steps[].estimate`.
+When querying available token-swapping routes or quotes, if the source token is in the approval-reset list, the need for an approval reset transaction will be indicated via an optional `approvalReset` field in the response's `steps[].estimate` dataset.
+
+---
+
+## 🤖 Bot identity & permissions
+
+- The bot is a GitHub App named `lifi-customizedtokenlist-bot`, installed on this repo only.
+- It has the minimum permissions needed: read/write on contents, issues, and pull requests; read on org members (to check team membership).
+- It does **not** receive webhooks and has **no** OAuth user-authentication flow — it only mints short-lived installation tokens inside Actions workflows.
+- Branch protection on `main` is configured to only allow pushes from `@lifinance/fullstack`, `@lifinance/techsupport`, and the bot.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,32 @@
+# Known limitations & follow-up work
+
+Tracked separately from the issue tracker so we don't lose context on intentional v1 simplifications. Promote to a real issue when someone starts work.
+
+---
+
+## Non-EVM address validation is hardcoded to Solana and Sui
+
+**File:** [`.github/scripts/apply-token.mjs`](./.github/scripts/apply-token.mjs) (`NON_EVM_CHAIN_IDS` constant)
+
+**What's there today:**
+The `/add-token` automation validates that the partner-supplied address looks like an EVM address (`0x` + 40 hex) unless the chain is on a small allowlist of known non-EVM chains:
+
+```js
+const NON_EVM_CHAIN_IDS = new Set([
+  1151111081099710 /* SOL */,
+  9270000000000000 /* SUI */,
+]);
+```
+
+**Why it's a limitation:**
+If we add a new non-EVM chain to the repo (Aptos, TON, Bitcoin, Cosmos chains, etc.), the script will incorrectly reject valid addresses for that chain because they don't match the EVM regex. The fix needs to either:
+
+- (a) extend the hardcoded set every time a new non-EVM chain lands, or
+- (b) replace the hardcoded set with a self-derived check that infers EVM-ness from the chain's existing token entries (e.g. peek at `tokens/<CHAIN_KEY>.json[0].address` and only enforce the EVM regex if the existing entries are EVM-shaped).
+
+**Why we haven't fixed it yet:**
+Before changing this, we want to check in with the team to understand how non-EVM address validation is done today across the broader LI.FI stack — there may be a canonical source-of-truth or existing helper we should align with rather than building our own heuristic.
+
+**Owner / next step:** raise in `#dev-backend-expansion` or `#dev-sc-review` to confirm the right pattern, then either (a) or (b) above. Estimated effort once the question is answered: ~10 minutes.
+
+---


### PR DESCRIPTION
## Summary

Replaces the current "anyone forks, anyone reviews, anyone merges" PR flow with a structured **two-lane model** for this repo. Driven by a Slack thread with @maxlin1 on 2026-05-19 in `#dev-backend-expansion-review` about the many-open-PRs problem and the rubber-stamp review pattern.

| | **Lane 1 — Internal** | **Lane 2 — External** |
|---|---|---|
| Who | Members of `@lifinance/fullstack` or `@lifinance/techsupport` | Partners, projects, community |
| Entry | Open a PR directly | Open an issue using the new ["Add a token"](.github/ISSUE_TEMPLATE/add-token.yml) form |
| Conversion | (none — PR is already open) | An internal comments `/add-token` on the issue → bot opens a PR |
| Review | None required — CI is the gate | None required — CI is the gate |
| Merge | Internal self-merges once CI is green | Internal self-merges once CI is green |

Fixes the "we don't know which Ledger contact opened this" attribution gap: the issue form captures partner identity (org + contact email) as required fields, and the bot threads that through into the PR body, commit trailer, and Slack notification.

## What's in this PR

- **Issue Form** (`.github/ISSUE_TEMPLATE/add-token.yml`) — structured submission with partner org, contact, **chain ID** (universal number, not LI.FI's internal 3-letter key), address, symbol, name, decimals, logo URL, justification, plus required confirmations. Blank issues disabled via `.github/ISSUE_TEMPLATE/config.yml`.
- **PR template** (`.github/pull_request_template.md`) — required "Source" field for partner attribution on direct PRs too.
- **CODEOWNERS** — both authorised teams as owners.
- **`/add-token` workflow** (`.github/workflows/add-token.yml`) — gated on team membership (checks the commenter is in `@lifinance/fullstack` or `@lifinance/techsupport` via the GitHub API; non-members get a 👎 reaction). Mints a short-lived installation token from the `lifi-customizedtokenlist-bot` GitHub App, parses the issue body, runs `apply-token.mjs`, opens a PR, and assigns the triggering internal. **The bot never merges** — a human always pulls the trigger.
- **`scripts/apply-token.mjs`** — builds a `chainId → filename` map at runtime by scanning `tokens/*.json` (self-updating: when a new chain file is added, no script change needed). Refuses on unknown chain IDs, duplicate addresses, malformed payloads. Outputs prettier-compliant 2-space JSON.
- **New-issue Slack notification** (`.github/workflows/issue-slack-notify.yml`) — pings `#dev-backend-expansion-review` on every new issue so requests don't sit unnoticed. User-controlled values escaped via `toJSON(format(...))`.
- **Fork-PR auto-close** (`.github/workflows/close-fork-prs.yml`) — politely auto-closes PRs from forks with a pointer to the issue template. (The "disable forking" toggle doesn't exist for public repos, so this workflow is the only enforcement — partners are still directed to the issue path.)
- **README.md** — expanded with the new flow + bot documentation at the top. **All original content preserved verbatim further down**: validation criteria, "How to add a new chain", "How to add your token" (kept as manual fallback), "How to block a token", "How to report EVM tokens requiring an approval reset".
- **CONTRIBUTING.md** — thin pointer to README.

## Auth model (no human credentials anywhere)

- New GitHub App `lifi-customizedtokenlist-bot` installed on this repo only. Permissions: contents/issues/PRs `write`, org members `read` (for team checks). Webhook disabled, OAuth disabled.
- Repo secrets already added: `TOKENLIST_BOT_APP_ID`, `TOKENLIST_BOT_PRIVATE_KEY`, `SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW`.
- The App was chosen over a PAT-on-machine-user because **App-token-opened PRs trigger downstream workflows** — the default `GITHUB_TOKEN` does not, due to GitHub's recursion guard. So our existing `validate.yml` / `lint.yml` / `semantic-pr.yml` CI still gates the bot's PRs.

## Pre-flight (local CodeRabbit pass)

Ran `coderabbit review --base origin/main --plain` per the team's `/pr-ready` workflow. 4 findings; 3 applied as separate `pr-ready:` commits (see git log), 1 deferred:

- ✅ Fixed: JSON injection via issue title / user login → `toJSON(format(...))` (`ad5a87d`)
- ✅ Fixed: branch name uses raw `\$SYMBOL` → lowercase + tr-alphanumeric + trim + fallback (`00a6fdd`)
- ✅ Fixed: `apply-token.mjs` failures had no user feedback → `continue-on-error` + follow-up step that posts the script's ❌ messages back to the issue and downvotes the comment (`8f56f35`)
- ⏭️ Deferred: bump `slackapi/slack-github-action` from v1.27.0 to v3.0.3. Major version bump can change inputs/outputs; release notes need a read-through before bumping. Not security-critical (only used for the new-issue notification). Will tackle in a follow-up PR.

## Manual setup before this is fully active

These can't be done via files and need a repo admin in the GitHub UI **after** this PR merges:

1. **Branch protection on `main`:**
   - Require status checks to pass before merging (the existing `validate.yml` / `lint.yml` / `semantic-pr.yml`).
   - Require branches to be up to date before merging.
   - 0 required reviewers.
   - **Restrict who can push to matching branches**: `@lifinance/fullstack`, `@lifinance/techsupport`, and `lifi-customizedtokenlist-bot`.
   - Include administrators: ☑

2. No "Disable forking" toggle exists for public repos — relying on `close-fork-prs.yml`.

## Coming next (v1.5, immediately after this lands)

Scheduled weekly **chain-coverage checker**: diffs `li.quest/v1/chains` against `tokens/*.json` chain IDs (same directory-scan map `apply-token.mjs` uses). If the backend supports a chain we don't have a file for, opens or updates a single tracking issue assigned to `@lifinance/techsupport`. ~30 lines of YAML + jq. Deliberately kept out of this PR to keep scope focused.

## Side effect to expect on the first bot-authored PR per chain

`apply-token.mjs` writes files with prettier-compliant 2-space JSON (matches the repo's `.prettierrc.json` + eslint config). A handful of existing entries have inconsistent indentation that pre-dates the formatter setup; the first time the bot touches a chain file, those get normalised as a side effect. After that, diffs are clean (~9 lines per token). Calling this out so reviewers aren't surprised when the first /add-token PR's diff is wider than expected.

## Test plan

- [ ] Merge this PR.
- [ ] Admin: configure branch protection per the "Manual setup" section above.
- [ ] Open a test issue using the new "Add a token" template (e.g. an obviously-test token on a sandbox chain) — confirm the Slack ping fires in `#dev-backend-expansion-review`.
- [ ] Comment `/add-token` on the test issue from a `@lifinance/fullstack` / `@lifinance/techsupport` member — confirm the bot opens a PR with the partner credited and the issue assigned to the commenter.
- [ ] Comment `/add-token` on the test issue from an external/non-member account — confirm 👎 reaction and no PR.
- [ ] Open a test issue with an unsupported chain ID — comment `/add-token` — confirm the failure message is posted back to the issue with the script's `❌` text.
- [ ] Open a test PR from a fork (use a personal fork) — confirm `close-fork-prs.yml` auto-closes with the friendly message.
- [ ] Close the test issue and revert any test entries from `tokens/*.json`.

## Origin

Slack thread with @maxlin1 in `#dev-backend-expansion-review` on 2026-05-19.