### PR TITLE
feat(issue-template): make contact email optional, credit GitHub handle by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-token.yml
+++ b/.github/ISSUE_TEMPLATE/add-token.yml
@@ -8,7 +8,9 @@ body:
       value: |
         Thanks for contributing! Fill in the fields below and an internal LI.FI team member will pick this up and turn it into a PR (typically within a few working days — we get a Slack notification the moment your issue is opened).
 
-        **All fields are required.** Incomplete submissions will be closed without action.
+        **All fields are required unless marked optional.** Incomplete submissions will be closed without action.
+
+        We'll reach out via GitHub on this issue if we have questions — your GitHub username is captured automatically when you open the issue, so an email address is only needed as a fallback contact.
 
         ⚠️ **The chain must already be supported in this repo** (browse the [`tokens/`](https://github.com/lifinance/customized-token-list/tree/main/tokens) folder — each file represents one chain). **If your chain isn't there yet, please [contact LI.FI support](https://help.li.fi/hc/en-us/requests/new) instead** — adding a new chain requires an internal team member to set it up first, and support will route the request to the right people.
 
@@ -24,11 +26,11 @@ body:
   - type: input
     id: contact
     attributes:
-      label: Contact email
-      description: How can we reach you if we have a question about this request?
+      label: Contact email (optional)
+      description: Fallback contact if we can't reach you on GitHub. Leave blank to be contacted via GitHub only.
       placeholder: e.g. partnerships@example.com
     validations:
-      required: true
+      required: false
 
   - type: input
     id: chainId

--- a/.github/workflows/add-token.yml
+++ b/.github/workflows/add-token.yml
@@ -101,7 +101,7 @@ jobs:
             };
             const payload = {
               partner: get('Partner / organization'),
-              contact: get('Contact email'),
+              contact: get('Contact email (optional)'),
               chainId: get('Chain ID'),
               address: get('Token contract address'),
               symbol: get('Symbol'),
@@ -112,6 +112,7 @@ jobs:
             };
             core.setOutput('payload', JSON.stringify(payload));
             core.setOutput('partner', payload.partner);
+            core.setOutput('contact', payload.contact);
             core.setOutput('symbol', payload.symbol);
             core.setOutput('chainId', payload.chainId);
 
@@ -152,7 +153,9 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUM: ${{ github.event.issue.number }}
           ACTOR: ${{ github.event.comment.user.login }}
+          OPENER: ${{ github.event.issue.user.login }}
           PARTNER: ${{ steps.parse.outputs.partner }}
+          CONTACT: ${{ steps.parse.outputs.contact }}
           SYMBOL: ${{ steps.parse.outputs.symbol }}
           CHAIN_ID: ${{ steps.parse.outputs.chainId }}
         run: |
@@ -169,10 +172,25 @@ jobs:
           git config user.email "lifi-customizedtokenlist-bot[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add -A
+
+          # Build optional trailers + body lines for the contact email (only
+          # included when the partner actually provided one — the field is
+          # optional in the issue form). GitHub @-mention of the opener is
+          # always present and is the primary reach-out channel.
+          CONTACT_TRAILER=""
+          CONTACT_BODY_LINE=""
+          if [ -n "$CONTACT" ]; then
+            CONTACT_TRAILER="
+          Contact-email: ${CONTACT}"
+            CONTACT_BODY_LINE="
+          - **Contact email:** ${CONTACT}"
+          fi
+
           git commit -m "feat: add ${SYMBOL} on chain ${CHAIN_ID} (closes #${ISSUE_NUM})
 
           Partner: ${PARTNER}
-          Triggered-by: @${ACTOR}"
+          Requested-by: @${OPENER}${CONTACT_TRAILER}
+          Bot-triggered-by: @${ACTOR}"
           git push origin "$BRANCH"
 
           PR_URL=$(gh pr create \
@@ -184,7 +202,8 @@ jobs:
 
           ## Source
           - **Partner / external request** — fulfils issue #${ISSUE_NUM}, partner: \`${PARTNER}\`
-          - **Triggered by:** @${ACTOR}
+          - **Requested by:** @${OPENER} (on behalf of \`${PARTNER}\`)${CONTACT_BODY_LINE}
+          - **Bot run triggered by:** @${ACTOR}
 
           ## Checklist
           - [ ] JSON validates (CI will confirm)


### PR DESCRIPTION
## Summary

Small follow-up to [#500](https://github.com/lifinance/customized-token-list/pull/500).

The partner's GitHub handle is captured automatically when they open the issue (they have to be logged in), and `@`-mentioning them on the issue or PR gets them a notification. So requiring an email field as the primary contact channel was redundant friction.

This change:

- Renames `Contact email` → `Contact email (optional)` and flips `required: true` → `required: false`.
- Surfaces the parsed `contact` value as a workflow step output (it was already being parsed but never used downstream).
- Always credits the issue opener in the bot-authored PR: adds a `Requested-by: @<opener>` git trailer + a `**Requested by:** @<opener> (on behalf of <partner>)` bullet in the PR body.
- Shows the contact email in the trailer + PR body **only when provided** — empty contact = no line, no awkward "Contact: (none)" rendering.
- Renames the existing `Triggered-by:` trailer to `Bot-triggered-by:` to disambiguate from `Requested-by:`.

## Why now

Reviewing the merged PR with Daniel, the required-email field stuck out as friction we don't actually need — every partner is already a known GitHub identity by the time they reach this form. Email stays available as a fallback for partners who want to be reached off-GitHub.

## Pre-flight

- ✅ YAML valid for both touched files
- ✅ Form label `Contact email (optional)` matches the parser's `get('Contact email (optional)')`
- ✅ Issue-Form body regex correctly handles labels with parentheses (verified locally)
- ✅ Conditional bash logic produces correct trailer + bullet when CONTACT is set or empty (verified locally — extracted the script via PyYAML, simulated end-to-end, confirmed both render flush-left after YAML block-scalar stripping)
- ✅ Branch rebased onto current `main` (no stale diffs — the original push would have silently deleted the new Bob token from `MON.json` since it had landed via PR #493 in the meantime)
- ⏭️ /pr-ready: 1 CR finding, rejected as false positive (CR misread YAML block-scalar indentation; proven by simulating the parsed bash output)

## Test plan

- [ ] Open a test token-request issue with the contact email field left blank — confirm the bot's PR has the `Requested by @opener` line but no `Contact email` line, and the commit trailer matches.
- [ ] Open another test issue with an email filled in — confirm both lines render correctly, no extra whitespace.