### PR TITLE
chore: remove CODEOWNERS to stop noisy auto-review-requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# These teams own this repo. PRs from non-team members are blocked at
-# branch protection (CI is the merge gate; no second-approver required).
-# Listing the teams here also makes them the default review-request target
-# for any PR opened in the repo.
-
-* @lifinance/fullstack @lifinance/techsupport


### PR DESCRIPTION
## Summary

Small follow-up to [#500](https://github.com/lifinance/customized-token-list/pull/500) and [#501](https://github.com/lifinance/customized-token-list/pull/501).

Deletes `.github/CODEOWNERS`. In this repo it was buying us only one thing in practice: GitHub auto-requesting reviews from `@lifinance/fullstack` and `@lifinance/techsupport` on every PR opened, which fires an email/notification to every team member per their personal settings.

For an internal-self-merge workflow where the same teams open many PRs (every new token request becomes a PR), that's pure noise — and noisy defaults train people to ignore notifications, which is the worst outcome.

## Why this is safe

| What CODEOWNERS was doing here | After removal |
|---|---|
| Auto-request reviews → emails everyone | Gone (intended) |
| Enable `require_code_owner_review` rule | We weren't using this rule anyway. Merge gating stays on the ruleset's `required_approving_review_count` |
| Push to `main` restriction | **Unchanged** — that's set in branch protection's `restrictions`, not CODEOWNERS |
| Default reviewer suggestion in UI | Minor loss; reviewers can be added manually for the rare PRs that genuinely need a second pair of eyes |

The actual security boundary (who can push/merge to `main`) is configured independently in branch protection and stays exactly as it is: `@lifinance/fullstack` + `@lifinance/techsupport` + the bot, with `enforce_admins: true`.

## Future option (deliberately not in this PR)

If we ever want a safety net for workflow/script changes specifically — the "compromised authorized account silently weakens the bot gate" social-engineering vector — we can re-add a **scoped** CODEOWNERS limited to the high-risk paths only:

```text
/.github/workflows/  @lifinance/fullstack @lifinance/techsupport
/.github/scripts/    @lifinance/fullstack @lifinance/techsupport
```

That would auto-request reviewers only for the rare workflow-change PRs and not for token PRs. Not doing it now because it adds nuance without proven need.

## Pre-flight

- ✅ Branch based on current `main` (post-#501)
- ✅ No references to CODEOWNERS anywhere else in the repo (`grep -r 'CODEOWNERS\|code owners'` clean)
- ✅ `/pr-ready` (CodeRabbit local): no findings
- ✅ Diff is one file, six lines deleted, nothing else touched

## Test plan

- [ ] After merge, open a throwaway PR (e.g. tweak a comment in this README) and confirm no auto-review-request fires.
- [ ] Confirm direct merge access to `main` is still gated to `fullstack`/`techsupport`/bot (the branch-protection `restrictions` field is unchanged).