### PR TITLE
fix: bump slackapi/slack-github-action v1.27.0 → v3.0.3 (incoming-webhook inputs)

### DIFF
--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -122,7 +122,7 @@ jobs:
             core.setOutput('title', newTitle);
 
       - name: Post to Slack
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Summary

**Latent bug caught on first real trigger.** The `on-new-issue` workflow (`.github/workflows/issue-slack-notify.yml`) uses the `webhook` + `webhook-type` inputs (slackapi's unified incoming-webhook pattern), which were introduced in v2.0.0. The previous pin at `v1.27.0` doesn't accept those inputs — every new issue ran the "Post to Slack" step and failed with:

```text
Warning: Unexpected input(s) 'webhook', 'webhook-type',
valid inputs are ['channel-id', 'slack-message', 'payload', 'payload-delimiter', 'payload-file-path', 'payload-file-path-parsed', 'update-ts']
Error: Need to provide at least one botToken or webhookUrl
```

Net effect: the team's `#dev-backend-expansion-review` channel never received the new-issue pings, so token-request / deny-request issues sat unnoticed.

## How it slipped through

CodeRabbit flagged exactly this on **PR #500** ("bump `slackapi/slack-github-action` to v3.0.3") with severity `major`. At the time I deferred it as "version bump may have breaking changes — needs a release-notes read-through" and documented it in PR #500's body. I never came back to it. The bug was latent for the entire period between #500 merging and today's smoke test because no real new issue had been opened on the repo to trigger the workflow until now.

This is a good reminder that **"defer CR finding"** has to come with a follow-up commitment, not just a note in the PR body.

## Fix

Bump the action's pinned SHA from `37ebaef…` (v1.27.0) to `45a88b9…` (v3.0.3):

- v3 accepts `webhook` + `webhook-type` + `payload` with the exact shape we already use — no payload-format changes needed.
- SHA pinned per [`~/.claude/CLAUDE.md`](https://github.com/lifinance/contracts) policy; tag kept as trailing comment for dependabot / human readers.

## Pre-flight

- ✅ YAML parses
- ✅ Diff is one line, in one workflow file
- ⏭️ `/pr-ready` (CodeRabbit local): skipped on user request — this is the same fix CR itself recommended on PR #500, so re-running CR on it is purely ceremonial.

## Test plan

- [ ] Merge.
- [ ] Open one of the test issues from the smoke-test plan (e.g. scenario 1 from the bulk-token-requests test plan).
- [ ] Confirm the "Post to Slack" step completes successfully and a ping appears in `#dev-backend-expansion-review`.
- [ ] If the issue has the `token-request` or `deny-request` label, confirm the title was rewritten before the Slack message fired (so the Slack ping shows the rewritten title).