### PR TITLE
feat: chain-name resolution + parser fix for multi-line fields

### DIFF
--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -51,14 +51,18 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            // Same field-extraction pattern as process-token-issue.yml.
-            // Issue Forms render each field as: ### <Label>\n\n<value>\n\n
+            // Split-based field parser. Same pattern as process-token-issue.yml.
+            // Issue Forms render each field as `### <Label>\n\n<value>\n\n`.
+            // Multi-line values (textareas, code-fence-wrapped `render: text` blocks)
+            // need to be captured in full — a non-greedy regex with a multi-line
+            // `\n*$` lookahead silently truncates them at the first newline, so we
+            // split on `### ` heading lines instead.
             const body = context.payload.issue.body || '';
             const fields = {};
-            const re = /^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n###\s+|\n*$)/gm;
-            let m;
-            while ((m = re.exec(body)) !== null) {
-              fields[m[1].trim()] = m[2].trim();
+            for (const section of body.split(/^### /m).slice(1)) {
+              const nl = section.indexOf('\n');
+              if (nl === -1) continue;
+              fields[section.slice(0, nl).trim()] = section.slice(nl + 1).trim();
             }
             const get = (label) => {
               const v = fields[label];
@@ -84,9 +88,36 @@ jobs:
             const address = get('Token contract address');
             // Symbol exists only on the add form; deny form has no symbol field.
             const symbol = requestType === 'add' ? get('Symbol') : '';
+
+            // Resolve the numeric chainId to a human chain name via LI.FI's
+            // /chains API (e.g. 1 → "Ethereum", 1151111081099710 → "Solana").
+            // Default endpoint returns EVM only — pass chainTypes explicitly so
+            // Solana / Sui / Bitcoin-like chains resolve too. Falls back
+            // gracefully to "chain <N>" on lookup failure, malformed input, or
+            // unknown chain ID.
+            async function resolveChainName(cid) {
+              if (!cid) return '';
+              const fallback = `chain ${cid}`;
+              try {
+                const controller = new AbortController();
+                const t = setTimeout(() => controller.abort(), 5000);
+                const res = await fetch('https://li.quest/v1/chains?chainTypes=EVM,SVM,UTXO,MVM', { signal: controller.signal });
+                clearTimeout(t);
+                if (!res.ok) return fallback;
+                const data = await res.json();
+                const match = (data.chains || []).find((c) => c.id === Number(cid));
+                return match && match.name ? match.name : fallback;
+              } catch (e) {
+                core.warning(`Chain-name lookup failed for chainId=${cid}: ${e.message}. Falling back to "${fallback}".`);
+                return fallback;
+              }
+            }
+            const chainName = await resolveChainName(chainId);
+            core.setOutput('chainName', chainName);
+
             // Compose the rewritten title differently per flow:
-            //   add  → "[token request] chain <id> <symbol>"
-            //   deny → "[deny request] chain <id> <0xshort…>"
+            //   add  → "[token request] <ChainName> <symbol>"
+            //   deny → "[deny request] <ChainName> <0xshort…>"
             let newTitle;
             if (requestType === 'add') {
               if (!chainId || !symbol) {
@@ -94,7 +125,7 @@ jobs:
                 core.setOutput('title', context.payload.issue.title);
                 return;
               }
-              newTitle = `[token request] chain ${chainId} ${symbol}`;
+              newTitle = `[token request] ${chainName} ${symbol}`;
             } else {
               if (!chainId || !address) {
                 core.warning(`Could not parse chainId="${chainId}" address="${address}" from issue body; leaving title unchanged.`);
@@ -103,7 +134,7 @@ jobs:
               }
               // Truncate the address for the title (full form is in the issue body).
               const shortAddr = address.length > 12 ? `${address.slice(0, 10)}…${address.slice(-4)}` : address;
-              newTitle = `[deny request] chain ${chainId} ${shortAddr}`;
+              newTitle = `[deny request] ${chainName} ${shortAddr}`;
             }
 
             if (newTitle === context.payload.issue.title) {

--- a/.github/workflows/process-token-issue.yml
+++ b/.github/workflows/process-token-issue.yml
@@ -130,14 +130,18 @@ jobs:
             core.setOutput('shouldContinue', 'true');
 
             // -------- 2. Parse the Issue Form body --------
-            // Issue Forms render each field as: ### <Label>\n\n<value>\n\n
-            // (or _No response_ for empty optional fields).
+            // Split-based parser. Issue Forms render each field as
+            // `### <Label>\n\n<value>\n\n`. Multi-line values (textareas, plus
+            // `render: text` blocks wrapped in ```` ```text … ``` ``` code
+            // fences) must be captured in full — a non-greedy regex with a
+            // multi-line `\n*$` lookahead silently truncates them at the
+            // first newline, so we split on `### ` heading lines instead.
             const issueBody = context.payload.issue.body || '';
             const fields = {};
-            const re = /^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n###\s+|\n*$)/gm;
-            let m;
-            while ((m = re.exec(issueBody)) !== null) {
-              fields[m[1].trim()] = m[2].trim();
+            for (const section of issueBody.split(/^### /m).slice(1)) {
+              const nl = section.indexOf('\n');
+              if (nl === -1) continue;
+              fields[section.slice(0, nl).trim()] = section.slice(nl + 1).trim();
             }
             const get = (label) => {
               const v = fields[label];
@@ -170,9 +174,14 @@ jobs:
               };
             }
 
-            // Parse JSON-line additional entries. Lines starting with '#' are
-            // comments. Parse errors are surfaced via payload.parseErrors so
-            // the apply script can report them alongside per-entry validation.
+            // Parse JSON-line additional entries. Skip:
+            //   - empty / whitespace-only lines
+            //   - comment lines (start with '#')
+            //   - GitHub-form code-fence markers (start with '```') — the form's
+            //     textarea uses `render: text`, which wraps content in fences
+            //   - any line that doesn't start with '{' (free-form prose etc.)
+            // Lines that DO start with '{' but fail JSON.parse are surfaced as
+            // parseErrors so the apply script can report them per-line.
             const additionalRaw = get(additionalFieldLabel);
             const additionalEntries = [];
             const parseErrors = [];
@@ -180,7 +189,10 @@ jobs:
               const lines = additionalRaw.split('\n');
               for (let i = 0; i < lines.length; i++) {
                 const trimmed = lines[i].trim();
-                if (!trimmed || trimmed.startsWith('#')) continue;
+                if (!trimmed) continue;
+                if (trimmed.startsWith('#')) continue;
+                if (trimmed.startsWith('```')) continue;
+                if (!trimmed.startsWith('{')) continue;
                 try {
                   additionalEntries.push(JSON.parse(trimmed));
                 } catch (e) {
@@ -205,6 +217,30 @@ jobs:
             // the address (truncated for the branch name downstream).
             core.setOutput('chainId', primaryEntry.chainId);
             core.setOutput('summaryLabel', requestType === 'add' ? primaryEntry.symbol : primaryEntry.address);
+
+            // Resolve the numeric chainId to a human chain name via LI.FI's
+            // /chains API (e.g. 1 → "Ethereum"). Used by the commit subject
+            // and PR title for human-readable output. Falls back to
+            // "chain <N>" on lookup failure / unknown chain so the workflow
+            // never blocks on this. Same logic as issue-slack-notify.yml.
+            async function resolveChainName(cid) {
+              if (!cid) return '';
+              const fallback = `chain ${cid}`;
+              try {
+                const controller = new AbortController();
+                const t = setTimeout(() => controller.abort(), 5000);
+                const res = await fetch('https://li.quest/v1/chains?chainTypes=EVM,SVM,UTXO,MVM', { signal: controller.signal });
+                clearTimeout(t);
+                if (!res.ok) return fallback;
+                const data = await res.json();
+                const match = (data.chains || []).find((c) => c.id === Number(cid));
+                return match && match.name ? match.name : fallback;
+              } catch (e) {
+                core.warning(`Chain-name lookup failed for chainId=${cid}: ${e.message}. Falling back to "${fallback}".`);
+                return fallback;
+              }
+            }
+            core.setOutput('chainName', await resolveChainName(primaryEntry.chainId));
 
       - name: Reject — issue has no matching label
         if: steps.gate.outputs.authorized == 'true' && steps.parse.outputs.shouldContinue == 'false'
@@ -273,6 +309,7 @@ jobs:
           CONTACT: ${{ steps.parse.outputs.contact }}
           SUMMARY_LABEL: ${{ steps.parse.outputs.summaryLabel }}
           CHAIN_ID: ${{ steps.parse.outputs.chainId }}
+          CHAIN_NAME: ${{ steps.parse.outputs.chainName }}
           TOKEN_COUNT: ${{ steps.parse.outputs.tokenCount }}
           REQUEST_TYPE: ${{ steps.parse.outputs.requestType }}
         run: |
@@ -336,12 +373,12 @@ jobs:
           # apply script's per-file breakdown so reviewers see the full list
           # without opening the diff.
           if [ "$TOKEN_COUNT" -le 1 ]; then
-            COMMIT_SUBJECT="feat: ${VERB} ${SUMMARY_LABEL} on chain ${CHAIN_ID} (closes #${ISSUE_NUM})"
-            PR_TITLE="${VERB_CAP} ${SUMMARY_LABEL} on chain ${CHAIN_ID} (${ORG_LABEL_LOWER}: ${PARTNER})"
+            COMMIT_SUBJECT="feat: ${VERB} ${SUMMARY_LABEL} on ${CHAIN_NAME} (closes #${ISSUE_NUM})"
+            PR_TITLE="${VERB_CAP} ${SUMMARY_LABEL} on ${CHAIN_NAME} (${ORG_LABEL_LOWER}: ${PARTNER})"
             PR_BREAKDOWN=""
           else
-            COMMIT_SUBJECT="feat: ${VERB} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on chain ${CHAIN_ID}) (closes #${ISSUE_NUM})"
-            PR_TITLE="${VERB_CAP} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on chain ${CHAIN_ID}) (${ORG_LABEL_LOWER}: ${PARTNER})"
+            COMMIT_SUBJECT="feat: ${VERB} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on ${CHAIN_NAME}) (closes #${ISSUE_NUM})"
+            PR_TITLE="${VERB_CAP} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on ${CHAIN_NAME}) (${ORG_LABEL_LOWER}: ${PARTNER})"
             BREAKDOWN_LINES=$(grep -E "^  ${LOG_PREFIX}" /tmp/apply.log | head -100 || true)
             PR_BREAKDOWN="
 


### PR DESCRIPTION
## Summary

Two improvements bundled (both surfaced during smoke-testing #507 / #503):

### 1. Chain-name resolution via li.quest API

Renders human chain names (`Ethereum`, `Arbitrum`, `Base`, `Solana`, …) instead of numeric chain IDs (`chain 1`, `chain 42161`) in the rewritten issue title, the Slack notification, the bot's commit subject, and the bot's PR title.

- Both workflows' parse steps now fetch `https://li.quest/v1/chains?chainTypes=EVM,SVM,UTXO,MVM` (default endpoint returns EVM only — chainTypes is needed for Solana/Sui)
- 5-second `AbortController` timeout so a stalled API can't hang the workflow
- Graceful fallback to `chain <N>` on lookup failure / malformed input / unknown chain

Verified locally:

| chainId | Resolved |
|---|---|
| 1 | Ethereum |
| 42161 | Arbitrum |
| 8453 | Base |
| 137 | Polygon |
| 56 | BSC |
| 1151111081099710 | Solana |
| 9270000000000000 | Sui |
| 99999 (unknown) | `chain 99999` |
| `abc` (malformed) | `chain abc` |

### 2. **CRITICAL — multi-line field parser was silently truncating bulk submissions**

The previous parser regex `/^###\s+(.+?)\s*\n+([\s\S]*?)(?=\n###\s+|\n*$)/gm` truncates multi-line field values at the first newline. In multiline mode (`m` flag), the lookahead's `\n*$` matches at every line ending, so the non-greedy `[\s\S]*?` capture stops immediately.

**Effect on real form submissions:**

- `Justification` field (multi-line prose): only the first line was captured. Cosmetic — we don't act on the value.
- `Additional tokens` / `Additional spam tokens` textarea (the bulk-submission feature): GitHub Issue Forms wrap `render: text` textareas in `` ```text … ``` `` code fences. The first line of the field value is the opening `` ```text `` marker — so the JSON-line content and closing fence were never captured. **All bulk submissions silently lost their additional entries and the bot produced single-token PRs even when partners submitted bulk requests.**

This bug has been latent since PR #503 shipped the bulk feature. We didn't catch it because my pre-flight tests in #503 fed `PAYLOAD` directly into the apply script, bypassing the parse step. No real bulk submission had fired the workflow until today's smoke testing exposed it.

**Fix:** replace the regex with a split-based parser that splits the body on `### ` heading lines (`body.split(/^### /m)`) and captures the full text between headings. Applied to both workflow files.

Additionally, the bulk-tokens line filter now:

- Skips lines starting with `` ``` `` (code-fence markers)
- Silently ignores any line that doesn't start with `{` (prose / comments / fences)
- Only `{`-starting lines are attempted as JSON and surfaced as parseErrors on failure

## Local verification (all 5 test scenarios)

Fed every test-script-generated body through the new parser. Each result:

| Scenario | Fields captured | Primary chainId | Additional tokens parsed |
|---|---|---|---|
| add-single | 11/11 | 8453 | 0 |
| add-bulk | 11/11 | 1 | 2 |
| add-dup | 11/11 | 1 | 2 |
| deny-single | 8/8 | 1 | 0 |
| deny-bulk | 8/8 | 1 | 3 |

All correct, zero false-positive parse errors.

## Test plan (post-merge)

I'll run `open-test-issue.sh` for each scenario from the local helper script, verify:

- Issue auto-labelled correctly (via the form template)
- Title rewritten with chain name ("Ethereum" not "chain 1")
- Slack notification lands in `#test-daniel` (current webhook target per Daniel's setup)
- Bot reacts 👀 → opens PR → reacts 🚀
- PR title uses chain name
- For bulk: PR contains all submitted tokens in the right files
- For dup: PR is rejected with atomic-reject error comment

Then close all test artifacts.