### PR TITLE
fix(slack): move ✅ inline so it's not confused with the user reaction

### DIFF
--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -199,7 +199,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "✅ Please mark this message with a checkmark reaction once the PR is merged, so the team knows it's handled."
+                      "text": "Please mark this message with a ✅ reaction once the PR is merged, so the team knows it's handled."
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary

Tiny UX polish on the new-issue Slack notification.

**Before:**
```
✅ Please mark this message with a checkmark reaction once the PR is merged...
[✅ 1]  ← actual user reaction
```

The two ✅ stacked on top of each other looked like duplicate reactions.

**After:**
```
Please mark this message with a ✅ reaction once the PR is merged...
[✅ 1]  ← actual user reaction
```

The ✅ now reads as part of the instruction (referring to the emoji you should add), not as an existing reaction-like decoration. Clean visual separation.

One-line change in `.github/workflows/issue-slack-notify.yml`.

## Local verification

YAML valid; Block Kit Builder preview confirms the new layout reads cleanly.