### PR TITLE
fix: bot PR titles use Conventional Commit prefix (feat:) so commitlint passes

### DIFF
--- a/.github/workflows/process-token-issue.yml
+++ b/.github/workflows/process-token-issue.yml
@@ -374,11 +374,11 @@ jobs:
           # without opening the diff.
           if [ "$TOKEN_COUNT" -le 1 ]; then
             COMMIT_SUBJECT="feat: ${VERB} ${SUMMARY_LABEL} on ${CHAIN_NAME} (closes #${ISSUE_NUM})"
-            PR_TITLE="${VERB_CAP} ${SUMMARY_LABEL} on ${CHAIN_NAME} (${ORG_LABEL_LOWER}: ${PARTNER})"
+            PR_TITLE="feat: ${VERB} ${SUMMARY_LABEL} on ${CHAIN_NAME} (${ORG_LABEL_LOWER}: ${PARTNER})"
             PR_BREAKDOWN=""
           else
             COMMIT_SUBJECT="feat: ${VERB} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on ${CHAIN_NAME}) (closes #${ISSUE_NUM})"
-            PR_TITLE="${VERB_CAP} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on ${CHAIN_NAME}) (${ORG_LABEL_LOWER}: ${PARTNER})"
+            PR_TITLE="feat: ${VERB} ${TOKEN_COUNT} ${NOUN} (incl. ${SUMMARY_LABEL} on ${CHAIN_NAME}) (${ORG_LABEL_LOWER}: ${PARTNER})"
             BREAKDOWN_LINES=$(grep -E "^  ${LOG_PREFIX}" /tmp/apply.log | head -100 || true)
             PR_BREAKDOWN="
 


### PR DESCRIPTION
Tiny one-line fix per branch. PR titles produced by the bot were missing the `feat:` prefix and failing the Validate-PR-Title check; the commit subject was already correct. Now they match. Discovered during end-to-end smoke test of #515 → #516.