### PR TITLE
fix: set -o pipefail in apply step so atomic-reject surfaces to the issue

### DIFF
--- a/.github/workflows/process-token-issue.yml
+++ b/.github/workflows/process-token-issue.yml
@@ -265,7 +265,16 @@ jobs:
         env:
           PAYLOAD: ${{ steps.parse.outputs.payload }}
           REQUEST_TYPE: ${{ steps.parse.outputs.requestType }}
+        # `set -o pipefail` is essential here: without it, the bash pipeline
+        # `node ... | tee` returns tee's exit code (always 0), so apply.outcome
+        # would be 'success' even when the apply script exited 1 (atomic
+        # reject, validation failure, etc.). That would skip the
+        # "Report apply failure back to issue" step and leave partners with
+        # only the 👀 reaction and no feedback. pipefail propagates node's
+        # exit code, so apply.outcome correctly becomes 'failure' on script
+        # failure and the report step fires.
         run: |
+          set -o pipefail
           if [ "$REQUEST_TYPE" = "add" ]; then
             node .github/scripts/apply-token.mjs 2>&1 | tee /tmp/apply.log
           else


### PR DESCRIPTION
## Summary

Tiny fix that closes the second bug found during today's end-to-end smoke testing.

When `apply-token.mjs` / `apply-deny-token.mjs` exits 1 (atomic reject etc.), the workflow's bash pipeline

```bash
node ... | tee /tmp/apply.log
```

returned tee's exit code (always 0), so `steps.apply.outcome` was incorrectly `success` even on real apply failures. The `Report apply failure back to issue` step's `if: ... apply.outcome == 'failure'` then evaluated false and skipped silently — partners saw only the 👀 reaction with no follow-up.

**Fix:** `set -o pipefail` at the top of the apply step. Bash now propagates node's exit code, `apply.outcome` correctly becomes `failure` on script failure, and the report step fires with the per-entry validation messages.

## Why this slipped through

The apply step has `continue-on-error: true` (intentional — we want the workflow to continue to the report step on apply failure). Combined with the pipe-eaten exit code, the step ALWAYS looked successful even when the script ran fine. My PR #503 pre-flight tested apply-token.mjs directly (without the workflow shell wrapper), so this never surfaced until a real apply failure ran in production today.

Same root cause as several other latent bugs in this repo's bot: workflows whose rare-trigger paths weren't exercised until real usage.

## Test plan (post-merge)

Re-run `./open-test-issue.sh --scenario add-dup --trigger` against main. Expected: bot reacts 👀, runs apply, apply exits 1 with atomic-reject message, bot now posts the failure as a comment to the issue (instead of silent), and the workflow shows red (intentional).