### PR TITLE
fix: resolve chain name from repo's tokens/ dir instead of li.quest API

### DIFF
--- a/.github/workflows/issue-slack-notify.yml
+++ b/.github/workflows/issue-slack-notify.yml
@@ -42,6 +42,19 @@ jobs:
           app-id: ${{ secrets.TOKENLIST_BOT_APP_ID }}
           private-key: ${{ secrets.TOKENLIST_BOT_PRIVATE_KEY }}
 
+      # Sparse checkout of just tokens/ so the parse step can resolve
+      # chainId → chain-key locally (no network dependency).
+      - name: Checkout tokens/ (for chain-name lookup)
+        if: >-
+          contains(github.event.issue.labels.*.name, 'token-request') ||
+          contains(github.event.issue.labels.*.name, 'deny-request')
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          sparse-checkout: |
+            tokens
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
       - name: Parse form fields and rewrite title
         id: parse
         if: >-
@@ -89,30 +102,39 @@ jobs:
             // Symbol exists only on the add form; deny form has no symbol field.
             const symbol = requestType === 'add' ? get('Symbol') : '';
 
-            // Resolve the numeric chainId to a human chain name via LI.FI's
-            // /chains API (e.g. 1 → "Ethereum", 1151111081099710 → "Solana").
-            // Default endpoint returns EVM only — pass chainTypes explicitly so
-            // Solana / Sui / Bitcoin-like chains resolve too. Falls back
-            // gracefully to "chain <N>" on lookup failure, malformed input, or
-            // unknown chain ID.
-            async function resolveChainName(cid) {
+            // Resolve the numeric chainId to its LI.FI chain key (e.g. 1 → "ETH",
+            // 8453 → "BAS") by scanning the tokens/ directory. The filename
+            // (minus .json) IS the chain key the rest of the LI.FI stack uses,
+            // so this is the authoritative mapping and stays in sync with the
+            // repo automatically — no network call, no flakiness.
+            //
+            // Falls back to "chain <N>" only when the chainId isn't in the
+            // repo at all (rare — would mean a new chain partners are
+            // requesting before it's been added to the repo).
+            const fs = require('node:fs');
+            const path = require('node:path');
+            function resolveChainName(cid) {
               if (!cid) return '';
+              const numId = Number(cid);
               const fallback = `chain ${cid}`;
+              if (!Number.isInteger(numId)) return fallback;
+              const tokensDir = path.resolve('tokens');
               try {
-                const controller = new AbortController();
-                const t = setTimeout(() => controller.abort(), 5000);
-                const res = await fetch('https://li.quest/v1/chains?chainTypes=EVM,SVM,UTXO,MVM', { signal: controller.signal });
-                clearTimeout(t);
-                if (!res.ok) return fallback;
-                const data = await res.json();
-                const match = (data.chains || []).find((c) => c.id === Number(cid));
-                return match && match.name ? match.name : fallback;
+                for (const filename of fs.readdirSync(tokensDir)) {
+                  if (!filename.endsWith('.json')) continue;
+                  try {
+                    const list = JSON.parse(fs.readFileSync(path.join(tokensDir, filename), 'utf8'));
+                    if (Array.isArray(list) && list.length > 0 && list[0].chainId === numId) {
+                      return filename.slice(0, -5); // strip ".json" → "ETH", "ARB", "BAS"
+                    }
+                  } catch { /* skip unreadable file */ }
+                }
               } catch (e) {
-                core.warning(`Chain-name lookup failed for chainId=${cid}: ${e.message}. Falling back to "${fallback}".`);
-                return fallback;
+                core.warning(`Chain-name lookup failed: ${e.message}. Falling back to "${fallback}".`);
               }
+              return fallback;
             }
-            const chainName = await resolveChainName(chainId);
+            const chainName = resolveChainName(chainId);
             core.setOutput('chainName', chainName);
 
             // Compose the rewritten title differently per flow:

--- a/.github/workflows/process-token-issue.yml
+++ b/.github/workflows/process-token-issue.yml
@@ -218,29 +218,41 @@ jobs:
             core.setOutput('chainId', primaryEntry.chainId);
             core.setOutput('summaryLabel', requestType === 'add' ? primaryEntry.symbol : primaryEntry.address);
 
-            // Resolve the numeric chainId to a human chain name via LI.FI's
-            // /chains API (e.g. 1 → "Ethereum"). Used by the commit subject
-            // and PR title for human-readable output. Falls back to
-            // "chain <N>" on lookup failure / unknown chain so the workflow
-            // never blocks on this. Same logic as issue-slack-notify.yml.
-            async function resolveChainName(cid) {
+            // Resolve the numeric chainId to its LI.FI chain key (e.g. 1 → "ETH",
+            // 8453 → "BAS") by scanning the tokens/ directory. The filename
+            // (minus .json) IS the chain key the rest of the LI.FI stack uses,
+            // so this is the authoritative mapping and stays in sync with the
+            // repo automatically — no network, no flakiness.
+            //
+            // Used by the commit subject and PR title for human-readable
+            // output. Falls back to "chain <N>" only when the chainId isn't
+            // in the repo at all (which would also cause the apply script to
+            // reject downstream — so the fallback never actually appears in a
+            // successful PR title).
+            const fs = require('node:fs');
+            const path = require('node:path');
+            function resolveChainName(cid) {
               if (!cid) return '';
+              const numId = Number(cid);
               const fallback = `chain ${cid}`;
+              if (!Number.isInteger(numId)) return fallback;
+              const tokensDir = path.resolve('tokens');
               try {
-                const controller = new AbortController();
-                const t = setTimeout(() => controller.abort(), 5000);
-                const res = await fetch('https://li.quest/v1/chains?chainTypes=EVM,SVM,UTXO,MVM', { signal: controller.signal });
-                clearTimeout(t);
-                if (!res.ok) return fallback;
-                const data = await res.json();
-                const match = (data.chains || []).find((c) => c.id === Number(cid));
-                return match && match.name ? match.name : fallback;
+                for (const filename of fs.readdirSync(tokensDir)) {
+                  if (!filename.endsWith('.json')) continue;
+                  try {
+                    const list = JSON.parse(fs.readFileSync(path.join(tokensDir, filename), 'utf8'));
+                    if (Array.isArray(list) && list.length > 0 && list[0].chainId === numId) {
+                      return filename.slice(0, -5); // strip ".json" → "ETH", "ARB", "BAS"
+                    }
+                  } catch { /* skip unreadable file */ }
+                }
               } catch (e) {
-                core.warning(`Chain-name lookup failed for chainId=${cid}: ${e.message}. Falling back to "${fallback}".`);
-                return fallback;
+                core.warning(`Chain-name lookup failed: ${e.message}. Falling back to "${fallback}".`);
               }
+              return fallback;
             }
-            core.setOutput('chainName', await resolveChainName(primaryEntry.chainId));
+            core.setOutput('chainName', resolveChainName(primaryEntry.chainId));
 
       - name: Reject — issue has no matching label
         if: steps.gate.outputs.authorized == 'true' && steps.parse.outputs.shouldContinue == 'false'


### PR DESCRIPTION
## Summary

Drop the li.quest API call for chainId → name resolution. Use the repo's `tokens/<KEY>.json` filename as the authoritative chain key instead.

## Why

Today's smoke testing exposed the li.quest call as flaky: 3 of 8 titles fell back to `chain N` because the 5s timeout intermittently fired. The repo already has the chainId → key mapping baked in (filename gives the key, first entry's `chainId` gives the chainId). Using it is faster, more reliable, and matches the convention the rest of the LI.FI stack uses.

## Trade-off

Titles now read `[token request] ETH USDC` instead of `[token request] Ethereum USDC`. Lossy on polish, gained on reliability and consistency. The key is what we use internally everywhere; the friendly name was nice-to-have.

If we ever want the friendly name back, we could add a small KEY → name table (e.g. `{ ETH: "Ethereum", ARB: "Arbitrum", … }`) that maps the resolved key to a display string. Easy follow-up.

## Implementation

- Both workflows' parse steps now scan `tokens/*.json` for a matching `chainId`, return the filename (sans `.json`) as the chain key.
- `process-token-issue.yml` already does a full `actions/checkout` for the apply step — no extra setup needed.
- `issue-slack-notify.yml` previously didn't check out anything (it just parsed the issue body); added a sparse-checkout step that fetches only `tokens/`. Adds ~3–5s of latency, similar to the API call it replaces.
- Fallback to `chain <N>` retained, but is essentially unreachable on the happy path (unsupported chainIds would be rejected by the apply script anyway).

## Local verification

| Input chainId | Resolved | Latency |
|---|---|---|
| 1 | ETH | 6ms |
| 42161 | ARB | 0ms |
| 8453 | BAS | 0ms |
| 137 | POL | 5ms |
| 56 | BSC | 1ms |
| 10 | OPT | 1ms |
| 1151111081099710 | SOL | 2ms |
| 9270000000000000 | SUI | 3ms |
| 99999 (unknown) | `chain 99999` | 3ms |
| `abc` (malformed) | `chain abc` | 0ms |

Compare to the previous resolver: 100–500ms+ when working, indefinite hangs (or 5s timeout → fallback) when not.

## Test plan after merge

Re-fire one or two of the existing manual-test scenarios — chain-name flakes should now be 0 / 0.