### PR TITLE
feat: auto-close issues on apply-failure to keep the repo clean

### DIFF
--- a/.github/workflows/process-token-issue.yml
+++ b/.github/workflows/process-token-issue.yml
@@ -313,9 +313,16 @@ jobs:
           ${ERROR}
           \`\`\`
 
-          Please correct the issue body (edit the original issue) and re-run \`${COMMAND}\`.
+          Closing this issue to keep the repo clean. To retry: edit the issue body with the corrected data and **reopen** the issue (or open a new one), then re-run \`${COMMAND}\`.
           EOF
           )"
+          # Close the issue so it doesn't sit open until someone manually
+          # cleans it up. Reason "not planned" matches the semantics: we
+          # didn't act on it as-submitted, but the requester can reopen
+          # (or open a new issue) with corrected data.
+          # `|| true` so a transient close failure doesn't mask the underlying
+          # apply error in the workflow status.
+          gh issue close "${{ github.event.issue.number }}" --reason "not planned" || true
           exit 1
 
       - name: Create branch, commit, push, open PR


### PR DESCRIPTION
## Summary

When `/add-token` or `/deny-token` triggers an atomic-reject (duplicate address, validation failure, etc.), the bot posts a failure comment but leaves the issue open. Requested by Daniel during smoke testing — auto-close keeps the repo from accumulating dead issues.

## Change

In the `Report apply failure back to issue` step of `process-token-issue.yml`, after the existing failure comment, add `gh issue close ... --reason "not planned"`.

Updated the comment wording to explicitly tell the requester they can edit + reopen (or open a new issue) and re-run the command.

## Behaviour comparison

| | Before | After |
|---|---|---|
| Apply rejects | Comment posted, issue stays open | Comment posted, **issue closed** with reason "not planned" |
| Apply succeeds | (unchanged) Bot opens PR, PR's `Closes #N` will close the issue on merge | (unchanged) |
| Re-running the command after fix | Edit issue body → re-run | Edit issue body, **reopen the issue**, → re-run (or open a new one) |

## `|| true` on the close call

`gh issue close` could fail transiently (rate limit, network, etc.). The `|| true` ensures a close failure doesn't crash the step before `exit 1` runs — so the workflow still ends in red status and the failure comment is the user-visible signal regardless.

## Test plan after merge

Re-run `./open-test-issue.sh --scenario add-dup --trigger` against main. Expected:

- Bot posts the atomic-reject failure comment with the new wording mentioning "Closing this issue to keep the repo clean"
- The issue auto-closes with reason "not planned"
- Reactions on the `/add-token` comment: 👀 then 👎

If we want to retry the same request: edit the issue body, click **Reopen**, then re-run `/add-token` — the bot processes the new content fresh.