### PR TITLE
feat: add yuzu token

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1026,7 +1026,7 @@
   {
     "address": "0xAFF2565091E7207191dBe340B8528D02FA78d044",
     "chainId": 1,
-    "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053", 
+    "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053",
     "decimals": 18,
     "name": "Asteroid",
     "symbol": "ASTEROID"
@@ -1034,9 +1034,33 @@
   {
     "address": "0xB197E02499e6502733C6bCE2eb39013C39A03147",
     "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg", 
+    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg",
     "decimals": 18,
     "name": "Wrapped PROS",
     "symbol": "PROS"
+  },
+  {
+    "name": "Yuzu USD",
+    "address": "0x387167e5C088468906Bcd67C06746409a8E44abA",
+    "symbol": "yzUSD",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png"
+  },
+  {
+    "name": "Staked Yuzu USD",
+    "address": "0x6DFF69eb720986E98Bb3E8b26cb9E02Ec1a35D12",
+    "symbol": "syzUSD",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png"
+  },
+  {
+    "name": "Yuzu Protection Pool",
+    "address": "0xB2429bA2cfa6387C9A336Da127d34480C069F851",
+    "symbol": "yzPP",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029"
   }
 ]

--- a/tokens/HYP.json
+++ b/tokens/HYP.json
@@ -206,5 +206,29 @@
     "chainId": 999,
     "decimals": 18,
     "logoURI": "https://storage.googleapis.com/zapper-fi-assets/tokens/ethereum/0x1d926bbe67425c9f507b9a0e8030eedc7880bf33.png"
+  },
+  {
+    "name": "Yuzu USD",
+    "address": "0xF72CE39998D2075f6661CF4214CfFE3cf38Da72f",
+    "symbol": "yzUSD",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png"
+  },
+  {
+    "name": "Staked Yuzu USD",
+    "address": "0x34C07f50c4f55B322E85DEeb265d278E6af112E4",
+    "symbol": "syzUSD",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png"
+  },
+  {
+    "name": "Yuzu Protection Pool",
+    "address": "0x8CBafE7847606FF9aC5eb5e8dd54E5459E8dcC51",
+    "symbol": "yzPP",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029"
   }
 ]

--- a/tokens/MON.json
+++ b/tokens/MON.json
@@ -136,11 +136,43 @@
     "logoURI": "https://assets.coingecko.com/coins/images/71550/standard/mhyperbtc-Bvh-K9IL.png"
   },
   {
-  "chainId": 143,
-  "address": "0x21E325B059Cd83d4037C82F0F5998Ba2dF3d7777",
-  "name": "Bob",
-  "symbol": "BOB",
-  "decimals": 18,
-  "logoURI": "https://assets.coingecko.com/coins/images/102173014/standard/main_mascot.png"
-}
+    "chainId": 143,
+    "address": "0x21E325B059Cd83d4037C82F0F5998Ba2dF3d7777",
+    "name": "Bob",
+    "symbol": "BOB",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102173014/standard/main_mascot.png"
+  },
+  {
+    "chainId": 143,
+    "address": "0x9dcB0D17eDDE04D27F387c89fECb78654C373858",
+    "name": "Yuzu USD",
+    "symbol": "yzUSD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png"
+  },
+  {
+    "chainId": 143,
+    "address": "0x484be0540aD49f351eaa04eeB35dF0f937D4E73f",
+    "name": "Staked Yuzu USD",
+    "symbol": "syzUSD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png"
+  },
+  {
+    "chainId": 143,
+    "address": "0xb37476cB1F6111cC682b107B747b8652f90B0984",
+    "name": "Yuzu Protection Pool",
+    "symbol": "yzPP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029"
+  },
+  {
+    "chainId": 143,
+    "address": "0xc9ea90692757831d98ac629f2a0140e02b80a7da",
+    "name": "Yuzu Prime",
+    "symbol": "yzPrime",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102173282/large/yPrime.png"
+  }
 ]

--- a/tokens/PLA.json
+++ b/tokens/PLA.json
@@ -30,5 +30,29 @@
     "decimals": 18,
     "chainId": 9745,
     "logoURI": "https://app.usd.ai/svg/erc20/susdai.svg"
+  },
+  {
+    "name": "Yuzu USD",
+    "address": "0x6695c0f8706c5ace3bdf8995073179cca47926dc",
+    "symbol": "yzUSD",
+    "decimals": 18,
+    "chainId": 9745,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png"
+  },
+  {
+    "name": "Staked Yuzu USD",
+    "address": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6",
+    "symbol": "syzUSD",
+    "decimals": 18,
+    "chainId": 9745,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png"
+  },
+  {
+    "name": "Yuzu Protection Pool",
+    "address": "0xebfc8c2fe73c431ef2a371aea9132110aab50dca",
+    "symbol": "yzPP",
+    "decimals": 18,
+    "chainId": 9745,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029"
   }
 ]

--- a/tokens/SEI.json
+++ b/tokens/SEI.json
@@ -62,5 +62,29 @@
     "chainId": 1329,
     "decimals": 18,
     "logoURI": "https://static.debank.com/image/eth_token/logo_url/0x96f6ef951840721adbf46ac996b59e0235cb985c/97c2e77af19822f6113485277496b32c.png"
+  },
+  {
+    "name": "Yuzu USD",
+    "address": "0x9dcB0D17eDDE04D27F387c89fECb78654C373858",
+    "symbol": "yzUSD",
+    "decimals": 18,
+    "chainId": 1329,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png"
+  },
+  {
+    "name": "Staked Yuzu USD",
+    "address": "0xB98b14d316d13f012d52f30A3d46641092AC6944",
+    "symbol": "syzUSD",
+    "decimals": 18,
+    "chainId": 1329,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png"
+  },
+  {
+    "name": "Yuzu Protection Pool",
+    "address": "0x5a4958AE05640b6483d44B45d36E5eBF7Cd20fe4",
+    "symbol": "yzPP",
+    "decimals": 18,
+    "chainId": 1329,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029"
   }
 ]


### PR DESCRIPTION
<!--
  PRs are restricted to members of @lifinance/fullstack and @lifinance/techsupport.
  External contributors: please open an issue using the "Add a token" template instead.
  See README.md for the full process.
-->

## Summary

  Add Yuzu protocol tokens across 5 chains

  Adds Yuzu native tokens to the LI.FI token list.

 ### Tokens added

  | Chain | Chain ID | Tokens |
  |---|---|---|
  | Ethereum | 1 | yzUSD, syzUSD, yzPP |
  | HyperEVM | 999 | yzUSD, syzUSD, yzPP |
  | Monad | 143 | yzUSD, syzUSD, yzPP, yzPrime |
  | Plasma | 9745 | yzUSD, syzUSD, yzPP |
  | Sei EVM | 1329 | yzUSD, syzUSD, yzPP |
  
## Source

<!-- Required. Pick one and fill in the details. -->

- [ ] **Internal request** — added by an internal team member (no upstream issue)
- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`

## Checklist

- [ ] JSON validates (CI will confirm)
- [ ] Logo URL is reachable and renders correctly
- [ ] Token contract address is checksummed and verified on the relevant block explorer
- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge
