### PR TITLE
fix(close-fork-prs): link to issue chooser instead of broken template URLs

### DIFF
--- a/.github/workflows/close-fork-prs.yml
+++ b/.github/workflows/close-fork-prs.yml
@@ -32,10 +32,10 @@ jobs:
           gh pr comment "$PR_URL" --body "$(cat <<EOF
           Hi @${AUTHOR} — thanks for contributing! 🙏
 
-          We don't accept pull requests from forks on this repo. Instead, please [**open a new issue**](${REPO_URL}/issues/new/choose) and pick one of these templates:
+          We don't accept pull requests from forks on this repo. Instead, please open an issue using one of these templates:
 
-          - **Add a token** — to request a new token (or many) be added to the list.
-          - **Report a scam token** — to report a malicious / phishing / impersonating token that should be blocked.
+          - **[Add a token](${REPO_URL}/issues/new?template=add-token.yml)** — to request a new token (or many) be added to the list.
+          - **[Report a scam token](${REPO_URL}/issues/new?template=add-deny-token.yml)** — to report a malicious / phishing / impersonating token that should be blocked.
 
           An internal LI.FI team member will pick it up and turn it into a PR within a few working days. Closing this PR for now — see the [README](${REPO_URL}/blob/main/README.md) for the full process.
           EOF

--- a/.github/workflows/close-fork-prs.yml
+++ b/.github/workflows/close-fork-prs.yml
@@ -27,16 +27,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           gh pr comment "$PR_URL" --body "$(cat <<EOF
           Hi @${AUTHOR} — thanks for contributing! 🙏
 
-          We don't accept pull requests from forks on this repo. Instead, please open an issue using one of these templates:
+          We don't accept pull requests from forks on this repo. Instead, please [**open a new issue**](${REPO_URL}/issues/new/choose) and pick one of these templates:
 
-          - **[Add a token](../../issues/new?template=add-token.yml)** — to request a new token (or many) be added to the list.
-          - **[Report a scam token](../../issues/new?template=add-deny-token.yml)** — to report a malicious / phishing / impersonating token that should be blocked.
+          - **Add a token** — to request a new token (or many) be added to the list.
+          - **Report a scam token** — to report a malicious / phishing / impersonating token that should be blocked.
 
-          An internal LI.FI team member will pick it up and turn it into a PR within a few working days. Closing this PR for now — see the [README](../../blob/main/README.md) for the full process.
+          An internal LI.FI team member will pick it up and turn it into a PR within a few working days. Closing this PR for now — see the [README](${REPO_URL}/blob/main/README.md) for the full process.
           EOF
           )"
           gh pr close "$PR_URL"


### PR DESCRIPTION
## Summary

- The auto-close comment on fork PRs used `../../issues/new?template=*.yml` relative links. Ric reported these were broken ([example](https://github.com/lifinance/customized-token-list/pull/494#issuecomment-4495643011)).
- **Root cause**: `../../` resolved against `…/pull/494` walks one segment too far → `https://github.com/lifinance/issues/new?…` (org, no repo) → 404. The `?template=*.yml` parameter itself works fine.
- **Fix**: keep the direct template links, but make them absolute via `${{ github.server_url }}/${{ github.repository }}`. Same one-click UX as originally intended.

## Test plan

- [ ] Open a fork PR (or trigger `pull_request_target` manually) and confirm the bot comment now renders **Add a token** and **Report a scam token** as direct links to the respective Issue Forms (not 404, not the chooser).
- [ ] Confirm the README link resolves to `https://github.com/lifinance/customized-token-list/blob/main/README.md`.