### PR TITLE
feat: add Yuzu Money tokens across PLA/ETH/HYP/MON/SEI (#534)

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1026,7 +1026,7 @@
   {
     "address": "0xAFF2565091E7207191dBe340B8528D02FA78d044",
     "chainId": 1,
-    "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053", 
+    "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053",
     "decimals": 18,
     "name": "Asteroid",
     "symbol": "ASTEROID"
@@ -1034,9 +1034,33 @@
   {
     "address": "0xB197E02499e6502733C6bCE2eb39013C39A03147",
     "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg", 
+    "logoURI": "https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/pharos.svg",
     "decimals": 18,
     "name": "Wrapped PROS",
     "symbol": "PROS"
+  },
+  {
+    "address": "0x387167e5C088468906Bcd67C06746409a8E44abA",
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png",
+    "decimals": 18,
+    "name": "Yuzu USD",
+    "symbol": "yzUSD"
+  },
+  {
+    "address": "0x6DFF69eb720986E98Bb3E8b26cb9E02Ec1a35D12",
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png",
+    "decimals": 18,
+    "name": "Staked Yuzu USD",
+    "symbol": "syzUSD"
+  },
+  {
+    "address": "0xB2429bA2cfa6387C9A336Da127d34480C069F851",
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029",
+    "decimals": 18,
+    "name": "Yuzu Protection Pool",
+    "symbol": "yzPP"
   }
 ]

--- a/tokens/HYP.json
+++ b/tokens/HYP.json
@@ -206,5 +206,29 @@
     "chainId": 999,
     "decimals": 18,
     "logoURI": "https://storage.googleapis.com/zapper-fi-assets/tokens/ethereum/0x1d926bbe67425c9f507b9a0e8030eedc7880bf33.png"
+  },
+  {
+    "address": "0xF72CE39998D2075f6661CF4214CfFE3cf38Da72f",
+    "chainId": 999,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png",
+    "decimals": 18,
+    "name": "Yuzu USD",
+    "symbol": "yzUSD"
+  },
+  {
+    "address": "0x34C07f50c4f55B322E85DEeb265d278E6af112E4",
+    "chainId": 999,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png",
+    "decimals": 18,
+    "name": "Staked Yuzu USD",
+    "symbol": "syzUSD"
+  },
+  {
+    "address": "0x8CBafE7847606FF9aC5eb5e8dd54E5459E8dcC51",
+    "chainId": 999,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029",
+    "decimals": 18,
+    "name": "Yuzu Protection Pool",
+    "symbol": "yzPP"
   }
 ]

--- a/tokens/MON.json
+++ b/tokens/MON.json
@@ -136,11 +136,43 @@
     "logoURI": "https://assets.coingecko.com/coins/images/71550/standard/mhyperbtc-Bvh-K9IL.png"
   },
   {
-  "chainId": 143,
-  "address": "0x21E325B059Cd83d4037C82F0F5998Ba2dF3d7777",
-  "name": "Bob",
-  "symbol": "BOB",
-  "decimals": 18,
-  "logoURI": "https://assets.coingecko.com/coins/images/102173014/standard/main_mascot.png"
-}
+    "chainId": 143,
+    "address": "0x21E325B059Cd83d4037C82F0F5998Ba2dF3d7777",
+    "name": "Bob",
+    "symbol": "BOB",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102173014/standard/main_mascot.png"
+  },
+  {
+    "address": "0x9dcB0D17eDDE04D27F387c89fECb78654C373858",
+    "chainId": 143,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png",
+    "decimals": 18,
+    "name": "Yuzu USD",
+    "symbol": "yzUSD"
+  },
+  {
+    "address": "0x484be0540aD49f351eaa04eeB35dF0f937D4E73f",
+    "chainId": 143,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png",
+    "decimals": 18,
+    "name": "Staked Yuzu USD",
+    "symbol": "syzUSD"
+  },
+  {
+    "address": "0xb37476cB1F6111cC682b107B747b8652f90B0984",
+    "chainId": 143,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029",
+    "decimals": 18,
+    "name": "Yuzu Protection Pool",
+    "symbol": "yzPP"
+  },
+  {
+    "address": "0xc9ea90692757831d98ac629f2a0140e02b80a7da",
+    "chainId": 143,
+    "logoURI": "https://assets.coingecko.com/coins/images/102173282/large/yPrime.png",
+    "decimals": 18,
+    "name": "Yuzu Prime",
+    "symbol": "yzPrime"
+  }
 ]

--- a/tokens/PLA.json
+++ b/tokens/PLA.json
@@ -30,5 +30,29 @@
     "decimals": 18,
     "chainId": 9745,
     "logoURI": "https://app.usd.ai/svg/erc20/susdai.svg"
+  },
+  {
+    "address": "0x6695c0f8706c5ace3bdf8995073179cca47926dc",
+    "chainId": 9745,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png",
+    "decimals": 18,
+    "name": "Yuzu USD",
+    "symbol": "yzUSD"
+  },
+  {
+    "address": "0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6",
+    "chainId": 9745,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png",
+    "decimals": 18,
+    "name": "Staked Yuzu USD",
+    "symbol": "syzUSD"
+  },
+  {
+    "address": "0xebfc8c2fe73c431ef2a371aea9132110aab50dca",
+    "chainId": 9745,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029",
+    "decimals": 18,
+    "name": "Yuzu Protection Pool",
+    "symbol": "yzPP"
   }
 ]

--- a/tokens/SEI.json
+++ b/tokens/SEI.json
@@ -62,5 +62,29 @@
     "chainId": 1329,
     "decimals": 18,
     "logoURI": "https://static.debank.com/image/eth_token/logo_url/0x96f6ef951840721adbf46ac996b59e0235cb985c/97c2e77af19822f6113485277496b32c.png"
+  },
+  {
+    "address": "0x9dcB0D17eDDE04D27F387c89fECb78654C373858",
+    "chainId": 1329,
+    "logoURI": "https://assets.coingecko.com/coins/images/70558/large/yzusd.png",
+    "decimals": 18,
+    "name": "Yuzu USD",
+    "symbol": "yzUSD"
+  },
+  {
+    "address": "0xB98b14d316d13f012d52f30A3d46641092AC6944",
+    "chainId": 1329,
+    "logoURI": "https://assets.coingecko.com/coins/images/70132/large/Group_427319351.png",
+    "decimals": 18,
+    "name": "Staked Yuzu USD",
+    "symbol": "syzUSD"
+  },
+  {
+    "address": "0x5a4958AE05640b6483d44B45d36E5eBF7Cd20fe4",
+    "chainId": 1329,
+    "logoURI": "https://assets.coingecko.com/coins/images/71043/large/yzPP_%281%29.png?1765442029",
+    "decimals": 18,
+    "name": "Yuzu Protection Pool",
+    "symbol": "yzPP"
   }
 ]


### PR DESCRIPTION
## Summary

Fulfils the external request in [issue #534](https://github.com/lifinance/customized-token-list/issues/534) (Yuzu Money — `xuan@yuzu.money`).

Adds **16 token entries** across 5 chains:

| Symbol | Chains |
|---|---|
| yzUSD (Yuzu USD) | Plasma · Ethereum · HyperEVM · Monad · Sei |
| syzUSD (Staked Yuzu USD) | Plasma · Ethereum · HyperEVM · Monad · Sei |
| yzPP (Yuzu Protection Pool) | Plasma · Ethereum · HyperEVM · Monad · Sei |
| yzPrime (Yuzu Prime) | Monad |

### Why a manual PR instead of `/add-token`?

The bot rejected the original issue with 15 JSON validation errors because the submitter's bulk-paste block had each entry split across two lines (URL on a separate line) plus the first ETH yzUSD entry was truncated. All the underlying data is correct — opening this PR directly avoids the partner having to re-edit + reopen the closed issue.

### Verification done before opening

- **On-chain `symbol()` call** against a public RPC for each of the 16 contracts → all return the expected symbol.
- **CoinGecko cross-check** for the listings that exist:
  - `yuzu-usd` → Plasma address matches
  - `staked-yuzu-usd` → Plasma + Monad addresses match
  - `yuzu-protection-pool` → Plasma address matches
  - `yuzu-prime` → Monad address matches
- **Submitter trust signal**: email domain (`yuzu.money`) matches project homepage.
- **Schema + tests**: `pnpm test` → 1515/1515 passing locally.
- **Image validator**: all 16 new logo URLs resolve (14 pre-existing failures unrelated to this PR).

## Test plan

- [ ] CI green
- [ ] Spot-check one address from each chain in the diff against the CoinGecko / issue body
- [ ] Merge → close #534

Closes #534