### PR TITLE
Add PUPCUP (Pup Cup) on Base

### DIFF
--- a/tokens/PUP.json
+++ b/tokens/PUP.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Pup Cup",
+    "address": "0x42BAb297f90e6285546F05abdF4C42D8415E9794",
+    "symbol": "PUPCUP",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://raw.githubusercontent.com/simplefarmer69/sushiswap-assets-fork/add-pupcup-base/blockchains/base/assets/0x42BAb297f90e6285546F05abdF4C42D8415E9794/logo.png"
+  }
+]


### PR DESCRIPTION
## Add PUPCUP (Pup Cup) on Base to Li.Fi customized token list

| Field | Value |
|---|---|
| Name | Pup Cup |
| Symbol | PUPCUP |
| Chain ID | 8453 (Base) |
| Address | `0x42BAb297f90e6285546F05abdF4C42D8415E9794` |
| Decimals | 18 |
| Website | https://theanvil.xyz |
| Basescan | https://basescan.org/token/0x42bab297f90e6285546f05abdf4c42d8415e9794 |
| DexScreener | https://dexscreener.com/base/0x42bab297f90e6285546f05abdf4c42d8415e9794 |

Source verified ✅ | 0% tax ✅ | LP locked 2027 ✅ | Active Uniswap V3 liquidity ✅
Li.Fi issue also filed: https://github.com/lifinance/types/issues/529