### PR TITLE
test: bump bCSPX logoURI to smoke-test notify-token-updates

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -5,7 +5,7 @@
     "symbol": "bCSPX",
     "decimals": 18,
     "chainId": 56,
-    "logoURI": "https://assets.coingecko.com/coins/images/31891/standard/bCSPX_200p.png?1740041074"
+    "logoURI": "https://assets.coingecko.com/coins/images/31891/standard/bCSPX_200p.png?1740041075"
   },
   {
     "name": "Backed Coinbase",


### PR DESCRIPTION
## Summary

One-character cache-bust on a single token's `logoURI` (`?1740041074` → `?1740041075`). The underlying image is unchanged.

**This is a smoke test for the workflow that just merged in [#540](https://github.com/lifinance/customized-token-list/pull/540).** After merging this PR, the new `notify-token-updates` workflow should detect that an existing `(56, 0x1e2C…1D59)` had its `logoURI` field modified and post a Slack message to the channel wired up via `SLACK_WEBHOOK_TOKEN_UPDATES`.

A follow-up PR will revert this change immediately to restore the original data.

## Test plan

- [ ] Merge.
- [ ] `notify-token-updates` workflow run goes green.
- [ ] Slack message lands listing `bCSPX` with `logoURI` as the changed field.
- [ ] Comment "this is just a test" under the Slack message.
- [ ] Open + merge the revert PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)