### PR TITLE
revert: restore bCSPX logoURI after notify-token-updates smoke test

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -5,7 +5,7 @@
     "symbol": "bCSPX",
     "decimals": 18,
     "chainId": 56,
-    "logoURI": "https://assets.coingecko.com/coins/images/31891/standard/bCSPX_200p.png?1740041075"
+    "logoURI": "https://assets.coingecko.com/coins/images/31891/standard/bCSPX_200p.png?1740041074"
   },
   {
     "name": "Backed Coinbase",


### PR DESCRIPTION
## Summary

Reverts [#541](https://github.com/lifinance/customized-token-list/pull/541), which was a deliberate one-character cache-bust on `bCSPX` `logoURI` to smoke-test the new `notify-token-updates` workflow from [#540](https://github.com/lifinance/customized-token-list/pull/540).

The smoke test [confirmed](https://github.com/lifinance/customized-token-list/actions/runs/26199417270) the workflow fires correctly on existing-token edits. This PR restores the original `logoURI` so the on-disk data matches what was there before the test.

When this PR merges, `notify-token-updates` will fire a *second* Slack alert (the revert is itself an edit to an existing token). That's expected, not a regression — the next change (whatever it is) will be a clean test of the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)