### PR TITLE
chore: route notify-token-updates to dev-backend-expansion-review

### DIFF
--- a/.github/workflows/notify-token-updates.yml
+++ b/.github/workflows/notify-token-updates.yml
@@ -49,6 +49,6 @@ jobs:
         if: steps.detect.outputs.has_updates == 'true'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_TOKEN_UPDATES }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW }}
           webhook-type: incoming-webhook
           payload: ${{ steps.detect.outputs.slack_payload }}


### PR DESCRIPTION
## Summary

Repoint the `notify-token-updates` workflow at the existing `SLACK_WEBHOOK_DEV_BACKEND_EXPANSION_REVIEW` secret so the alert lands in `#dev-backend-expansion-review` — the same channel where [`issue-slack-notify.yml`](../blob/main/.github/workflows/issue-slack-notify.yml#L180) already posts. Admin-key holders see both token-related pings in one place.

Drops the standalone `SLACK_WEBHOOK_TOKEN_UPDATES` requirement from [#540](https://github.com/lifinance/customized-token-list/pull/540).

## Cleanup

After this merges:
- [ ] Remove the unused `SLACK_WEBHOOK_TOKEN_UPDATES` secret from repo settings (Settings → Secrets and variables → Actions).

## Test plan

- [ ] Merge.
- [ ] On the next merge that edits an existing token's metadata, confirm the alert lands in `#dev-backend-expansion-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)