### PR TITLE
Add ZARO (Zaro Coin) to BSC token list (chainId 56)

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -552,7 +552,7 @@
     "logoURI": "https://assets.coingecko.com/coins/images/68596/standard/spgion_160x160.png"
   },
   {
-    "name": "Petróleo Brasileiro S.A.",
+    "name": "Petr\u00f3leo Brasileiro S.A.",
     "address": "0x2b1d5cdecc356530a746c5754231efaeaca64022",
     "symbol": "PBRon",
     "chainId": 56,
@@ -1398,5 +1398,13 @@
     "chainId": 56,
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/71751/standard/wcc.jpg?1769157740"
+  },
+  {
+    "address": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc",
+    "chainId": 56,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png",
+    "decimals": 18,
+    "name": "Zaro Coin",
+    "symbol": "ZARO"
   }
 ]


### PR DESCRIPTION
## Token Addition: Zaro Coin (ZARO) — BSC

**Contract:** `0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc`
**Chain:** BSC (chainId 56)
**Decimals:** 18
**Logo:** https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png
**Website:** https://www.zarocoin.xyz
**CoinGecko:** https://www.coingecko.com/en/coins/zaro-coin
**CoinMarketCap:** https://coinmarketcap.com/currencies/zaro-coin/

ETH (chainId 1) was added in PR #548. This is the BSC Wormhole-bridged version.

**Contact:** shihab@zaroverse.com