### PR TITLE
feat: add USDT.e and USDC.e on MOP

### DIFF
--- a/tokens/MOP.json
+++ b/tokens/MOP.json
@@ -6,5 +6,21 @@
     "decimals": 18,
     "name": "BitgetToken",
     "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/BGB.svg"
+  },
+  {
+    "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+    "chainId": 2818,
+    "symbol": "USDT.e",
+    "decimals": 6,
+    "name": "Bridged USDT",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDT.e.svg"
+  },
+  {
+    "address": "0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B",
+    "chainId": 2818,
+    "symbol": "USDC.e",
+    "decimals": 6,
+    "name": "Bridged USDC",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDC.e.svg"
   }
 ]


### PR DESCRIPTION
## Summary

Adds two bridged stablecoins on the Morph (MOP, chainId 2818) chain:

- **USDT.e** (`Bridged USDT`) — `0xe7cd86e13AC4309349F30B3435a9d337750fC82D`, decimals 6 ([explorer](https://explorer.morph.network/token/0xe7cd86e13AC4309349F30B3435a9d337750fC82D))
- **USDC.e** (`Bridged USDC`) — `0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B`, decimals 6 ([explorer](https://explorer.morph.network/token/0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B))

Logos are sourced from the official [`morph-l2/morph-list`](https://github.com/morph-l2/morph-list) repository (`USDT.e.svg`, `USDC.e.svg`), matching the convention already used by the existing `BGB` entry in `tokens/MOP.json`.

The `.e` suffix is the standard LI.FI convention for bridged variants (see `ERA.json`, `CRN.json`, `SOE.json`, `XDC.json`).

## Test plan

- [x] `pnpm test` — schema validation passes (1548/1548)
- [x] `pnpm lint` — no errors
- [x] `pnpm validateImages` — logo URIs resolve
- [x] Decimals (6) verified against Morph explorer API for both tokens


Made with [Cursor](https://cursor.com)