### PR TITLE
feat: add USDT.e and USDC.e on MOP

### DIFF
--- a/tokens/MOP.json
+++ b/tokens/MOP.json
@@ -6,5 +6,21 @@
     "decimals": 18,
     "name": "BitgetToken",
     "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/BGB.svg"
+  },
+  {
+    "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+    "chainId": 2818,
+    "symbol": "USDT.e",
+    "decimals": 6,
+    "name": "USDT.e",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDT.e.svg"
+  },
+  {
+    "address": "0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B",
+    "chainId": 2818,
+    "symbol": "USDC.e",
+    "decimals": 6,
+    "name": "USDC.e",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDC.e.svg"
   }
 ]


### PR DESCRIPTION
## Summary

Adds two bridged stablecoins on the Morph (`MOP`, chainId `2818`) chain:

| Symbol | Address | Decimals | Source |
|---|---|---|---|
| `USDT.e` | [`0xe7cd86e13AC4309349F30B3435a9d337750fC82D`](https://explorer.morph.network/token/0xe7cd86e13AC4309349F30B3435a9d337750fC82D) | 6 | USDT0 |
| `USDC.e` | [`0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B`](https://explorer.morph.network/token/0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B) | 6 | USDC |

`.e` suffix follows the LI.FI convention for bridged variants (matches `ERA.json`, `CRN.json`, `SOE.json`, `XDC.json`).

Logos sourced from the official [`morph-l2/morph-list`](https://github.com/morph-l2/morph-list) repo, consistent with the existing `BGB` entry on this chain.

## Test plan

- [x] `pnpm test` — 1548/1548 passing
- [x] `pnpm lint` — clean
- [x] Decimals (6) verified against the Morph Blockscout API for both contracts


Made with [Cursor](https://cursor.com)