### PR TITLE
fix: correct USDT.e and USDC.e addresses on MOP

### DIFF
--- a/tokens/MOP.json
+++ b/tokens/MOP.json
@@ -8,7 +8,7 @@
     "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/BGB.svg"
   },
   {
-    "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+    "address": "0xc7D67A9cBB121b3b0b9c053DD9f469523243379A",
     "chainId": 2818,
     "symbol": "USDT.e",
     "decimals": 6,
@@ -16,7 +16,7 @@
     "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDT.e.svg"
   },
   {
-    "address": "0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B",
+    "address": "0xe34c91815d7fc18A9e2148bcD4241d0a5848b693",
     "chainId": 2818,
     "symbol": "USDC.e",
     "decimals": 6,


### PR DESCRIPTION
## Summary

Follow-up to #561: the USDT.e and USDC.e entries added there pointed at the wrong contracts on Morph (chainId 2818). Swapping in the correct canonical bridged stablecoin addresses.

| Symbol | Old (#561, wrong) | New (this PR) | Decimals |
|---|---|---|---|
| `USDT.e` | [`0xe7cd86e13AC4309349F30B3435a9d337750fC82D`](https://explorer.morph.network/token/0xe7cd86e13AC4309349F30B3435a9d337750fC82D) (USDT0) | [`0xc7D67A9cBB121b3b0b9c053DD9f469523243379A`](https://explorer.morph.network/token/0xc7D67A9cBB121b3b0b9c053DD9f469523243379A) (Tether USD) | 6 |
| `USDC.e` | [`0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B`](https://explorer.morph.network/token/0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B) (USDC, newer) | [`0xe34c91815d7fc18A9e2148bcD4241d0a5848b693`](https://explorer.morph.network/token/0xe34c91815d7fc18A9e2148bcD4241d0a5848b693) (USD Coin) | 6 |

Symbols, names, and logoURIs are unchanged from #561 — only the on-chain addresses are corrected.

## Test plan

- [x] `pnpm test` — 1548/1548 passing
- [x] `pnpm lint` — clean
- [x] Decimals (6) verified against the Morph Blockscout API for both new contracts


Made with [Cursor](https://cursor.com)