### PR TITLE
feat: add USDT0 and USDC on MOP

### DIFF
--- a/tokens/MOP.json
+++ b/tokens/MOP.json
@@ -22,5 +22,21 @@
     "decimals": 6,
     "name": "USDC.e",
     "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDC.e.svg"
+  },
+  {
+    "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+    "chainId": 2818,
+    "symbol": "USDT0",
+    "decimals": 6,
+    "name": "USDT0",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDT0.svg"
+  },
+  {
+    "address": "0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B",
+    "chainId": 2818,
+    "symbol": "USDC",
+    "decimals": 6,
+    "name": "USDC",
+    "logoURI": "https://raw.githubusercontent.com/morph-l2/morph-list/main/tokenIcons/USDC.svg"
   }
 ]


### PR DESCRIPTION
## Summary

Adds two additional stablecoin variants on Morph (`MOP`, chainId `2818`), complementing the existing `USDT.e` / `USDC.e` entries:

| Symbol | Name | Address | Decimals |
|---|---|---|---|
| `USDT0` | `USDT0` | [`0xe7cd86e13AC4309349F30B3435a9d337750fC82D`](https://explorer.morph.network/token/0xe7cd86e13AC4309349F30B3435a9d337750fC82D) | 6 |
| `USDC` | `USDC` | [`0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B`](https://explorer.morph.network/token/0xCfb1186F4e93D60E60a8bDd997427D1F33bc372B) | 6 |

Symbols and names match the on-chain ERC-20 metadata exactly (verified via the Morph Blockscout API). Logos are sourced from the official [`morph-l2/morph-list`](https://github.com/morph-l2/morph-list) repo, consistent with all other Morph entries.

Existing `USDT.e` / `USDC.e` entries (the canonical bridged variants added in #561 / #562) are unchanged.

## Test plan

- [x] `pnpm test` — 1550/1550 passing
- [x] `pnpm lint` — clean
- [x] Decimals (6) verified against the Morph Blockscout API for both contracts


Made with [Cursor](https://cursor.com)