### PR TITLE
feat: add BGB on ETH

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1078,5 +1078,13 @@
     "decimals": 8,
     "name": "ICP",
     "symbol": "ICP"
+  },
+  {
+    "address": "0x54D2252757e1672EEaD234D27B1270728fF90581",
+    "chainId": 1,
+    "logoURI": "https://storage.googleapis.com/zapper-fi-assets/tokens/ethereum/0x54d2252757e1672eead234d27b1270728ff90581.png",
+    "decimals": 18,
+    "name": "Bitget Token",
+    "symbol": "BGB"
   }
 ]


### PR DESCRIPTION
## Summary

Adds Bitget Token (BGB) on Ethereum mainnet (chainId 1).

| Field | Value |
|---|---|
| `address` | [`0x54D2252757e1672EEaD234D27B1270728fF90581`](https://etherscan.io/token/0x54D2252757e1672EEaD234D27B1270728fF90581) |
| `symbol` | `BGB` |
| `name` | `Bitget Token` |
| `decimals` | 18 |
| `logoURI` | Zapper asset CDN |

Same project as the existing BGB entry on Morph (`tokens/MOP.json`). CoinGecko id [`bitget-token`](https://www.coingecko.com/en/coins/bitget-token) confirms the address, symbol, name, and decimals.

## Test plan

- [x] `pnpm test` — 1551/1551 passing
- [x] `pnpm lint` — clean
- [x] Decimals (18) and metadata verified via CoinGecko API


Made with [Cursor](https://cursor.com)