### PR TITLE
feat: bootstrap KAT chain and add BMX on ETH/FRA/KAT (partner: Boardwalk)

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1086,5 +1086,13 @@
     "decimals": 18,
     "name": "Bitget Token",
     "symbol": "BGB"
+  },
+  {
+    "address": "0xd55159FE5633e24510D5317d224324413407C5B8",
+    "chainId": 1,
+    "logoURI": "https://www.useboardwalk.com/images/power/logo.svg",
+    "decimals": 18,
+    "name": "Boardwalk",
+    "symbol": "BMX"
   }
 ]

--- a/tokens/FRA.json
+++ b/tokens/FRA.json
@@ -30,5 +30,13 @@
     "decimals": 18,
     "name": "FRAX",
     "logoURI": "https://static.debank.com/image/movr_token/logo_url/0x965f84d915a9efa2dd81b653e3ae736555d945f4/1f2c42cba1add081f314ee899ab67816.png"
+  },
+  {
+    "address": "0xEA34EbBC94df7BfEC5D9CDCd373a4221B7c87810",
+    "chainId": 252,
+    "symbol": "BMX",
+    "decimals": 18,
+    "name": "Boardwalk",
+    "logoURI": "https://www.useboardwalk.com/images/power/logo.svg"
   }
 ]

--- a/tokens/KAT.json
+++ b/tokens/KAT.json
@@ -1,0 +1,10 @@
+[
+  {
+    "address": "0xbDcAAa7439a0Fc6E01326d36Ab8d72cCeeCD1f5A",
+    "chainId": 747474,
+    "logoURI": "https://www.useboardwalk.com/images/power/logo.svg",
+    "decimals": 18,
+    "name": "Boardwalk",
+    "symbol": "BMX"
+  }
+]


### PR DESCRIPTION
Closes #565.

## Summary
Bootstraps the Katana chain (chainId `747474`) and adds BMX (Boardwalk) on Ethereum, Fraxtal, and Katana — all from a single partner request that couldn't run through `/add-token` because Katana wasn't yet a supported chain in the repo.

## Source
- **Partner / external request** — fulfils issue #565, partner: `Boardwalk`
- **Requested by:** @daedboi (on behalf of `Boardwalk`)
- **Contact email:** 0xedboi@bmx.trade
- **Entry count:** 3 tokens + 1 new chain file

## Changes
- `tokens/KAT.json` (new) — bootstraps chainId `747474` (Katana) per README §"How to add a new chain"; seeded with the BMX entry. Chain key `kat` confirmed via `https://li.quest/v1/chains`.
- `tokens/ETH.json` — BMX on Ethereum (`0xd55159FE5633e24510D5317d224324413407C5B8`)
- `tokens/FRA.json` — BMX on Fraxtal (`0xEA34EbBC94df7BfEC5D9CDCd373a4221B7c87810`)

## Why a manual PR (not `/add-token`)
The bot's `apply-token.mjs` rejects unsupported chainIds atomically — since chainId `747474` had no `tokens/*.json` file, the entire 3-token batch in #565 would fail validation. Per README §"How to add a new chain", chain bootstrapping is a manual prerequisite. Bundling the bootstrap + the 3 BMX entries here avoids two PRs and a partner round-trip.

## Checklist
- [ ] JSON validates (CI will confirm)
- [ ] Logo URLs are reachable and render correctly
- [ ] Token contract addresses are checksummed and verified on the relevant block explorers

Made with [Cursor](https://cursor.com)