### PR TITLE
feat: deny transfer-restricted token on BSC

### DIFF
--- a/denyTokens/BSC.json
+++ b/denyTokens/BSC.json
@@ -293,5 +293,10 @@
     "chainId": 56,
     "address": "0x3Ad7DaCb4573De5B01BF720cb4A86B296f05abb4",
     "reason": "Non-standard token transfer restrictions make LI.FI requiresDeposit=true routes structurally unexecutable for normal swap amounts."
+  },
+  {
+    "chainId": 56,
+    "address": "0x8A972Ed397bEd7C0Cbc84cc3EFbC760bb07F80bb",
+    "reason": "Transfer-restricted (anti-bot cooldown). Sim reverts 'Transfer too soon, please wait.' — fails regardless of slippage. Tenderly sim: https://www.tdly.co/shared/simulation/96879db6-dfd5-4e0b-92ef-cfa3700d686b"
   }
 ]


### PR DESCRIPTION
0x8A972Ed397bEd7C0Cbc84cc3EFbC760bb07F80bb has an anti-bot cooldown that reverts transfers with "Transfer too soon, please wait." Routes fail regardless of slippage, so block it.

<!--
  PRs are restricted to members of @lifinance/fullstack and @lifinance/techsupport.
  External contributors: please open an issue using the "Add a token" template instead.
  See README.md for the full process.
-->

## Summary

<!-- One line: what is this PR adding / changing? -->

## Source

<!-- Required. Pick one and fill in the details. -->

- [ ] **Internal request** — added by an internal team member (no upstream issue)
- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`

## Checklist

- [ ] JSON validates (CI will confirm)
- [ ] Logo URL is reachable and renders correctly
- [ ] Token contract address is checksummed and verified on the relevant block explorer
- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge
