### PR TITLE
feat: deny scam airdropped token on Base

### DIFF
--- a/denyTokens/BAS.json
+++ b/denyTokens/BAS.json
@@ -53,5 +53,10 @@
     "address": "0xb6E38746AfD8C1dB4481C709AEbf0e3b2794F752",
     "chainId": 8453,
     "reason": "BSA (Block Sec Arena) scam token blocking transfers"
+  },
+  {
+    "address": "0x499f9F464C9a652dFC142662e7468f7b392b77a0",
+    "chainId": 8453,
+    "reason": "Scam airdropped token"
   }
 ]


### PR DESCRIPTION
## Summary
Blocks a scam airdropped token on Base (chainId 8453) via denyTokens/BAS.json.

- Address: 0x499f9F464C9a652dFC142662e7468f7b392b77a0
- Chain: Base (8453)
- Reason: Scam airdropped token

## Test plan
- [ ] validate.yml passes (schema + single-chainId-per-file)
- [ ] lint.yml passes