### PR TITLE
feat: add SPCXx xStock (ETH/ARB/OPT/BSC) and SPCXon on SOL

### DIFF
--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -590,5 +590,13 @@
     "decimals": 18,
     "name": "Stable Coin",
     "symbol": "SBC"
+  },
+  {
+    "address": "0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28",
+    "chainId": 42161,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102173688/large/SPCXx.png",
+    "decimals": 18,
+    "name": "SpaceX xStock",
+    "symbol": "SPCXx"
   }
 ]

--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -1430,5 +1430,13 @@
     "decimals": 18,
     "name": "SpaceX (Ondo Tokenized)",
     "symbol": "SPCXon"
+  },
+  {
+    "address": "0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28",
+    "chainId": 56,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102173688/large/SPCXx.png",
+    "decimals": 18,
+    "name": "SpaceX xStock",
+    "symbol": "SPCXx"
   }
 ]

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1118,5 +1118,13 @@
     "decimals": 18,
     "name": "SpaceX (Ondo Tokenized)",
     "symbol": "SPCXon"
+  },
+  {
+    "address": "0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28",
+    "chainId": 1,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102173688/large/SPCXx.png",
+    "decimals": 18,
+    "name": "SpaceX xStock",
+    "symbol": "SPCXx"
   }
 ]

--- a/tokens/OPT.json
+++ b/tokens/OPT.json
@@ -198,5 +198,13 @@
     "decimals": 18,
     "name": "Midas Re7 Ethereum",
     "symbol": "mRe7ETH"
+  },
+  {
+    "address": "0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28",
+    "chainId": 10,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102173688/large/SPCXx.png",
+    "decimals": 18,
+    "name": "SpaceX xStock",
+    "symbol": "SPCXx"
   }
 ]

--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -134,5 +134,13 @@
     "decimals": 8,
     "name": "Zaro Coin",
     "symbol": "ZARO"
+  },
+  {
+    "address": "wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo",
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spcxon_160x160.png",
+    "decimals": 9,
+    "name": "SpaceX (Ondo Tokenized)",
+    "symbol": "SPCXon"
   }
 ]


### PR DESCRIPTION
## Summary

Add **SpaceX xStock (SPCXx)** on Ethereum, Arbitrum, Optimism and BSC, and **SpaceX Ondo Tokenized (SPCXon)** on Solana — so both appear in the default token list independently of third-party indexing (some deployments, e.g. SPCXx on Optimism, are not yet picked up by Debank/Zerion/Zapper).

| Token | Chain | Address | Decimals |
|---|---|---|---|
| SPCXx (SpaceX xStock) | ETH (1) | `0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28` | 18 |
| SPCXx (SpaceX xStock) | ARB (42161) | `0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28` | 18 |
| SPCXx (SpaceX xStock) | OPT (10) | `0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28` | 18 |
| SPCXx (SpaceX xStock) | BSC (56) | `0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28` | 18 |
| SPCXon (SpaceX Ondo Tokenized) | SOL (1151111081099710) | `wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo` | 9 |

SPCXon on ETH and BSC was already added in #591, so this PR only adds the missing Solana deployment for it.

## Source

- [x] **Internal request** — added by an internal team member (no upstream issue). Official addresses provided by the issuer (Ondo tokenized SpaceX).

## Checklist

- [x] JSON validates (CI will confirm)
- [x] Logo URL is reachable and renders correctly (verified `200 image/png` for both CoinGecko SPCXx and Ondo CDN SPCXon logos)
- [x] Token contract address is checksummed and verified
- [x] No external issue to link

Made with [Cursor](https://cursor.com)