### PR TITLE
feat: deny scam token impersonating SpaceX (SPCXx) on Solana

### DIFF
--- a/denyTokens/SOL.json
+++ b/denyTokens/SOL.json
@@ -28,5 +28,10 @@
     "chainId": 1151111081099710,
     "address": "WEvsSbEe8SmDsZQmmKv4FsHTNAqVgdNuaB1Sxc1JvH5",
     "reason": "Scam WETH token with active freeze authority."
+  },
+  {
+    "chainId": 1151111081099710,
+    "address": "wzAdC34eo4sSxR2CwznSURSACxAc5JyJwgq92ycRbvr",
+    "reason": "Scam token impersonating SpaceX (Ondo/xStock). Spoofs symbol SPCXx and embeds the legitimate SPCXon token addresses (wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo / 0xc9eef266834730340A55B6CC24621B31BAF55581) in its name to mislead users."
   }
 ]


### PR DESCRIPTION
## Summary
- Adds Solana token `wzAdC34eo4sSxR2CwznSURSACxAc5JyJwgq92ycRbvr` to `denyTokens/SOL.json`.
- The token is a **scam impersonating the SpaceX tokens** we recently listed (#593). It spoofs the symbol `SPCXx` and stuffs the **legitimate SPCXon addresses** into its on-chain name to appear authentic:
  - SOL: `wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo`
  - ETH: `0xc9eef266834730340A55B6CC24621B31BAF55581`

## Verification
- LI.FI token API returns this address under symbol `SPCXx` with a misleading name embedding the real token addresses.
- Not previously present in `denyTokens/` or `tokens/`.
- JSON parses; schema/chainId validation passes (only pre-existing, unrelated `SOM.json` test failure remains in local env).

Made with [Cursor](https://cursor.com)