### PR TITLE
feat: deny unofficial Kraken token on Ink (57073)

### DIFF
--- a/denyTokens/INK.json
+++ b/denyTokens/INK.json
@@ -3,5 +3,10 @@
     "chainId": 57073,
     "address": "0xbf0cAfCbaaF0be8221Ae8d630500984eDC908861",
     "reason": "Fee taking token SQUIDS"
+  },
+  {
+    "chainId": 57073,
+    "address": "0xCa5f2cCBD9C40b32657dF57c716De44237f80F05",
+    "reason": "Unofficial Kraken branded token with owner-controlled blacklist"
   }
 ]


### PR DESCRIPTION
## Summary

Adds a deny-list entry for an unofficial **Kraken**-branded token on **Ink** (chainId `57073`).

| Field | Value |
|---|---|
| Chain | Ink (`57073`) |
| Address | `0xCa5f2cCBD9C40b32657dF57c716De44237f80F05` |
| Reason | Unofficial Kraken branded token with owner-controlled blacklist |

The token impersonates the Kraken brand and the owner can blacklist arbitrary holders, so it should not surface in the default token list.

## Test plan

- [x] `pnpm run test` — deny-token schema + chainId validation passes for `denyTokens/INK.json` (the only failing cases, `OUT.json`/`SOM.json`, are pre-existing and unrelated to this change, caused by a stale local `@lifi/types`).
- [x] `prettier --check` passes.

Made with [Cursor](https://cursor.com)