### PR TITLE
feat: add USDY on BSC

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -1454,5 +1454,13 @@
     "decimals": 18,
     "name": "Cap",
     "symbol": "CAP"
+  },
+  {
+    "address": "0x608593d17A2decBbc4399e4185bE4922F97eD32E",
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usdy_160x160.png",
+    "decimals": 18,
+    "name": "Ondo U.S. Dollar Yield",
+    "symbol": "USDY"
   }
 ]


### PR DESCRIPTION
Add Ondo U.S. Dollar Yield (USDY) to the BSC custom token list.

<!--
  PRs are restricted to members of @lifinance/fullstack and @lifinance/techsupport.
  External contributors: please open an issue using the "Add a token" template instead.
  See README.md for the full process.
-->

## Summary

<!-- One line: what is this PR adding / changing? -->

## Source

<!-- Required. Pick one and fill in the details. -->

- [ ] **Internal request** — added by an internal team member (no upstream issue)
- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`

## Checklist

- [ ] JSON validates (CI will confirm)
- [ ] Logo URL is reachable and renders correctly
- [ ] Token contract address is checksummed and verified on the relevant block explorer
- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge
