### PR TITLE
feat: add BSPx (Bending Spoons xStock) on BSC and Ink

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -1462,5 +1462,13 @@
     "decimals": 18,
     "name": "Ondo U.S. Dollar Yield",
     "symbol": "USDY"
+  },
+  {
+    "name": "Bending Spoons xStock",
+    "address": "0x7796f4e23a62ef3653829c21032a9e24beaf4cf5",
+    "symbol": "BSPx",
+    "chainId": 56,
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102174230/standard/BSPx.png"
   }
 ]

--- a/tokens/INK.json
+++ b/tokens/INK.json
@@ -22,5 +22,13 @@
     "decimals": 18,
     "name": "Boardwalk",
     "symbol": "BMX"
+  },
+  {
+    "name": "Bending Spoons xStock",
+    "address": "0x7796f4e23a62ef3653829c21032a9e24beaf4cf5",
+    "symbol": "BSPx",
+    "chainId": 57073,
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102174230/standard/BSPx.png"
   }
 ]


### PR DESCRIPTION
## Summary

Adds the **Bending Spoons xStock (`BSPx`)** token to two EVM chains:

| Chain | chainId | Address |
|---|---|---|
| BSC | 56 | `0x7796f4e23a62ef3653829c21032a9e24beaf4cf5` |
| Ink | 57073 | `0x7796f4e23a62ef3653829c21032a9e24beaf4cf5` |

- `decimals`: 18 (consistent with other xStocks on EVM, e.g. SPCXx)
- Shared EVM address across chains (same convention as SPCXx), distributed via xChange
- Logo: `https://assets.coingecko.com/coins/images/102174230/standard/BSPx.png`

BSPx is xStocks' second tokenized IPO (after SPCXx/SpaceX), a 1:1 backed tokenized representation of Bending Spoons (Nasdaq: BSP) equity, tradable via xChange on EVM and Solana.

> Note: Ethereum is handled separately; Mantle was intentionally left out of this PR per request.

## Test plan

- [x] `pnpm run test` — both new entries pass schema + chainId validation (`Bending Spoons xStock on chain 56`, `... on chain 57073`)
- [x] `pnpm run lint` — clean
- [x] JSON parses for both files
- [x] Logo URL returns `200` / `image/png`
- [ ] CI green on PR

_(The 2 unrelated `OUT.json`/`SOM.json` filename failures seen locally are due to a stale local `@lifi/types` and pre-date this change.)_

Made with [Cursor](https://cursor.com)