### PR TITLE
feat: add LINK/SOL/WBTC and deny USDC.e/USDT on 0G (ZEROG)

### DIFF
--- a/denyTokens/ZEROG.json
+++ b/denyTokens/ZEROG.json
@@ -1,0 +1,12 @@
+[
+  {
+    "chainId": 16661,
+    "address": "0x8a2B28364102Bea189D99A475C494330Ef2bDD0B",
+    "reason": "USDC.e not traded by Stargate on 0G"
+  },
+  {
+    "chainId": 16661,
+    "address": "0x9FBBAFC2Ad79af2b57eD23C60DfF79eF5c2b0FB5",
+    "reason": "USDT not traded by Stargate on 0G"
+  }
+]

--- a/tokens/ZEROG.json
+++ b/tokens/ZEROG.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "address": "0x76159c2b43ff6f630193e37ec68452169914c1bb",
+    "decimals": 18,
+    "chainId": 16661,
+    "logoURI": "https://assets.coingecko.com/coins/images/877/standard/chainlink-new-logo.png"
+  },
+  {
+    "name": "Wrapped SOL",
+    "symbol": "SOL",
+    "address": "0x2b269f9deb4804c5a4bd97e4d951c775beaa0cc5",
+    "decimals": 9,
+    "chainId": 16661,
+    "logoURI": "https://assets.coingecko.com/coins/images/4128/standard/solana.png"
+  },
+  {
+    "name": "Wrapped BTC",
+    "symbol": "WBTC",
+    "address": "0x0555e30da8f98308edb960aa94c0db47230d2b9c",
+    "decimals": 8,
+    "chainId": 16661,
+    "logoURI": "https://assets.coingecko.com/coins/images/7598/standard/wrapped_bitcoin_wbtc.png"
+  }
+]


### PR DESCRIPTION
Add ZEROG (chainId 16661) token file with LINK, SOL, and WBTC. Deny USDC.e and USDT on 0G as they are not traded by Stargate.

<!--
  PRs are restricted to members of @lifinance/fullstack and @lifinance/techsupport.
  External contributors: please open an issue using the "Add a token" template instead.
  See README.md for the full process.
-->

## Summary

<!-- One line: what is this PR adding / changing? -->

## Source

<!-- Required. Pick one and fill in the details. -->

- [ ] **Internal request** — added by an internal team member (no upstream issue)
- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`

## Checklist

- [ ] JSON validates (CI will confirm)
- [ ] Logo URL is reachable and renders correctly
- [ ] Token contract address is checksummed and verified on the relevant block explorer
- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge
