### PR TITLE
fix: correct decimals for MOLLARS and imgnAI (9, not 18)

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -283,7 +283,7 @@
     "address": "0x18e692c03de43972fe81058f322fa542ae1a5e2c",
     "chainId": 8453,
     "logoURI": "https://static.debank.com/image/eth_token/logo_url/0xa735a3af76cc30791c61c10d585833829d36cbe0/574009b28ce2f77459a084c68d347564.png",
-    "decimals": 18,
+    "decimals": 9,
     "name": "Image Generation AI",
     "symbol": "imgnAI"
   },

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -427,7 +427,7 @@
     "address": "0x385d65ed9241e415cfc689c3e0bcf5ab2f0505c2",
     "chainId": 1,
     "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/31642.png",
-    "decimals": 18,
+    "decimals": 9,
     "name": "MollarsToken",
     "symbol": "MOLLARS"
   },
@@ -443,7 +443,7 @@
     "address": "0xA735A3AF76CC30791C61c10d585833829d36CBe0",
     "chainId": 1,
     "logoURI": "https://static.debank.com/image/eth_token/logo_url/0xa735a3af76cc30791c61c10d585833829d36cbe0/574009b28ce2f77459a084c68d347564.png",
-    "decimals": 18,
+    "decimals": 9,
     "name": "Image Generation AI",
     "symbol": "imgnAI"
   },


### PR DESCRIPTION
## Summary

Corrects the `decimals` field for 3 token entries that were set to `18` but are actually `9` on-chain. The wrong value in this custom list overrides the correct on-chain value in the backend pricing pipeline, which broke exchanges for these tokens.

Reported by **Tangem**: users were unable to perform exchanges due to the decimals mismatch.

| Token | Chain | Address | Was | Now (on-chain) |
|-------|-------|---------|-----|----------------|
| MOLLARS | Ethereum | `0x385d65ed9241e415cfc689c3e0bcf5ab2f0505c2` | 18 | **9** |
| imgnAI | Ethereum | `0xA735A3AF76CC30791C61c10d585833829d36CBe0` | 18 | **9** |
| imgnAI | Base | `0x18e692c03de43972fe81058f322fa542ae1a5e2c` | 18 | **9** |

## Verification

On-chain `decimals()` (selector `0x313ce567`) returns `0x...09` = **9** for all three:

```
ETH  0x385d65ed9241e415cfc689c3e0bcf5ab2f0505c2 -> 9
ETH  0xa735a3af76cc30791c61c10d585833829d36cbe0 -> 9
BASE 0x18e692c03de43972fe81058f322fa542ae1a5e2c -> 9
```

## Notes

- A `PATCH /v1/token` re-fetch does **not** fix this, because `CustomListOracle` metadata overrides the fetched decimals — the correction has to happen in this list.
- After merge, the backend picks up the change within ~1h (custom-list cache TTL).

Made with [Cursor](https://cursor.com)