### PR TITLE
feat: add AMZNx (Amazon.com xStock) on ETH with logoURI

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1024,6 +1024,14 @@
     "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/NVDAx.png"
   },
   {
+    "name": "Amazon.com xStock",
+    "address": "0x3557ba345b01efa20a1bddc61f573bfd87195081",
+    "symbol": "AMZNx",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://xstocks-metadata.backed.fi/logos/tokens/AMZNx.png"
+  },
+  {
     "address": "0xAFF2565091E7207191dBe340B8528D02FA78d044",
     "chainId": 1,
     "logoURI": "https://assets.coingecko.com/coins/images/102172917/standard/IMG_3076.jpg?1776670053",


### PR DESCRIPTION
## Summary

Adds **AMZNx (Amazon.com xStock)** on Ethereum to the custom token list with a `logoURI`.

The token already resolves via `GET /v1/token` (lazy-loaded + priced), but it was **not** in the custom list, so its `logoURI` came back `null`. This adds it alongside the existing TSLAx / NVDAx xStock entries.

| Token | Chain | Address | logoURI |
|-------|-------|---------|---------|
| AMZNx | Ethereum | `0x3557ba345b01efa20a1bddc61f573bfd87195081` | `https://xstocks-metadata.backed.fi/logos/tokens/AMZNx.png` |

## Verification

- Token exists on-chain / via API: `GET /v1/token?chain=1&token=0x3557...5081` → `Amazon.com xStock`, `AMZNx`, decimals `18`.
- Logo URL returns **HTTP 200** (same `backed.fi` pattern used by TSLAx/NVDAx).

## Notes

- TSLAx and NVDAx are already present in the list — no change needed for those.
- After merge, the backend picks up the new logo within ~1h (custom-list cache TTL).

Made with [Cursor](https://cursor.com)