### PR TITLE
feat: deny scam USDY honeypot on Solana

### DIFF
--- a/denyTokens/SOL.json
+++ b/denyTokens/SOL.json
@@ -33,5 +33,10 @@
     "chainId": 1151111081099710,
     "address": "wzAdC34eo4sSxR2CwznSURSACxAc5JyJwgq92ycRbvr",
     "reason": "Scam token impersonating SpaceX (Ondo/xStock). Spoofs symbol SPCXx and embeds the legitimate SPCXon token addresses (wzAyQTorWyoVXuJKj2x8EqKEGJpS13z6EWE9z5Aondo / 0xc9eef266834730340A55B6CC24621B31BAF55581) in its name to mislead users."
+  },
+  {
+    "chainId": 1151111081099710,
+    "address": "USDvuSdHZUcj67tKfvVzByG9MaBAJRyeRrBSDLmMg75",
+    "reason": "Scam token impersonating Ondo USDY (Ondo US Dollar Yield). Vanity mint spoofs the USDY symbol/name and has an active freeze authority (Bw1EuXufEzbwRqbDDetbjWHAXRdU2s5TaURWgnH1vTm) that can freeze holder accounts and lock funds (honeypot)."
   }
 ]


### PR DESCRIPTION
## Summary

Blocks a scam token on **Solana** that impersonates **Ondo USDY**.

| Field | Value |
|-------|-------|
| Address (mint) | `USDvuSdHZUcj67tKfvVzByG9MaBAJRyeRrBSDLmMg75` |
| Chain | Solana (`1151111081099710`) |
| Impersonates | Ondo USDY / "Ondo US Dollar Yield" |

Currently the API serves this mint as `USDY` / "Ondo US Dollar Yield" at ~$1.13 — i.e. users see it as the legitimate token.

## Why it's a honeypot / scam

- **Impersonation:** vanity mint (`USDv…`) spoofs the USDY symbol/name; it is **not** the real Ondo USDY mint.
- **Active freeze authority:** `Bw1EuXufEzbwRqbDDetbjWHAXRdU2s5TaURWgnH1vTm` — the deployer can freeze holders' token accounts and lock funds.

## Verification

`getAccountInfo` (jsonParsed) on Solana mainnet:
```json
{
  "program": "spl-token",
  "decimals": 6,
  "mintAuthority": null,
  "freezeAuthority": "Bw1EuXufEzbwRqbDDetbjWHAXRdU2s5TaURWgnH1vTm",
  "supply": "159410206000000"
}
```

Made with [Cursor](https://cursor.com)