### PR TITLE
feat: fix Ondo USDY (Solana) logo with working CoinGecko image

### DIFF
--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -158,5 +158,13 @@
     "decimals": 8,
     "name": "SK hynix xStock",
     "symbol": "SKHYx"
+  },
+  {
+    "address": "A1KLoBrKBde8Ty9qtNQUtq3C2ortoC3u7twggz7sEto6",
+    "chainId": 1151111081099710,
+    "symbol": "USDY",
+    "decimals": 6,
+    "name": "Ondo US Dollar Yield",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
   }
 ]


### PR DESCRIPTION
## Summary

Fixes the missing/broken logo for the **real Ondo USDY** on Solana by adding it to the custom list with a working `logoURI`.

| Field | Value |
|-------|-------|
| Address (mint) | `A1KLoBrKBde8Ty9qtNQUtq3C2ortoC3u7twggz7sEto6` |
| Chain | Solana (`1151111081099710`) |
| Symbol / Name | USDY / Ondo US Dollar Yield |
| Decimals | 6 |
| logoURI | `https://coin-images.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524` |

## Why

The token's on-chain metadata logo (an Arweave URL) is **dead — returns HTTP 404**:
`https://hq3wjgefwtje2kue7bvqlevhns2udaharnibucrgui3lhgy4aniq.arweave.net/PDdkmIW00k0qhPhrBZKnbLVBgOCLUBoKJqI2s5scA1E`

A `PATCH /v1/token` re-fetch keeps pulling that same dead URL, so the fix is to override the logo via the custom list.

## Verification

- Broken Arweave logo: `HTTP 404`.
- New CoinGecko logo: `HTTP 200`, `content-type: image/png`.
- Token confirmed as the legitimate Ondo USDY mint on Solana (distinct from the impersonator `USDvuSdHZUcj67tKfvVzByG9MaBAJRyeRrBSDLmMg75`, blocked separately).

After merge, the logo propagates within ~1h (custom-list cache TTL).

Made with [Cursor](https://cursor.com)