### PR TITLE
fix: deny 3 airdrop tokens with inflated price feeds on ETH (DOGX, MEZO, ROBO)

### DIFF
--- a/denyTokens/ETH.json
+++ b/denyTokens/ETH.json
@@ -373,5 +373,20 @@
     "chainId": 1,
     "address": "0x865ec58b06bF6305B886793AA20A2da31D034E68",
     "reason": "This is our deprecated 2018 contract."
+  },
+  {
+    "chainId": 1,
+    "address": "0xF28ccD4e6a2faAD9ab050e181273ccf24BC36A70",
+    "reason": "Airdrop/spam token with grossly inflated price feed (~$292M per token from a manipulated low-liquidity pool). Distorts partner fee dashboards. Deny until a reliable price source exists."
+  },
+  {
+    "chainId": 1,
+    "address": "0x423f8211085db9b3C8f4fDA3569af3f52BEe93Bf",
+    "reason": "Airdrop/spam token with grossly inflated price feed (~$5.3M per token from a manipulated low-liquidity pool). Distorts partner fee dashboards. Deny until a reliable price source exists."
+  },
+  {
+    "chainId": 1,
+    "address": "0xa6C5Ec3F4B31e37770aFE102540caC1b2AB004bc",
+    "reason": "Airdrop/spam token with grossly inflated price feed (~$21K per token from a manipulated low-liquidity pool). Distorts partner fee dashboards. Deny until a reliable price source exists."
   }
 ]


### PR DESCRIPTION
## Summary

Deny three airdrop/spam tokens on Ethereum whose LI.FI price feeds are grossly inflated, distorting partner fee dashboards.

| Token | Address | LI.FI price/token | Real value |
|---|---|---|---|
| DOGX | 0xF28ccD4e6a2faAD9ab050e181273ccf24BC36A70 | ~$292,065,636 | ~$0 |
| MEZO | 0x423f8211085db9b3C8f4fDA3569af3f52BEe93Bf | ~$5,342,718 | ~$0 |
| ROBO | 0xa6C5Ec3F4B31e37770aFE102540caC1b2AB004bc | ~$21,204 | ~$0 |

## Context

Reported by a partner (Bitpanda / smart-wallet): the Partner Portal Fees Collectible dashboard showed a value orders of magnitude higher than on-chain reality on Ethereum. The fee-receiver EOA 0xc53D7c1498996e7937a61317460EAC2a48594DAa (~286 tokens, mostly airdrop spam) was valued by LI.FI at ~$611,000,000 vs ~$11,500 real (almost all USDC). Inflation comes entirely from these airdrop tokens, priced from manipulated low-liquidity DEX pools with no plausibility cap. DOGX + MEZO alone account for ~$610M.

## Notes
- Deny is a stopgap; follow-up for the pricing team: add a price-plausibility / min-liquidity guard.
- Other mispriced candidates on the same address (lower balance): DIXT, XChat