### PR TITLE
fix: correct wstETH logo on Robinhood chain (was placeholder string)

### DIFF
--- a/tokens/OUT.json
+++ b/tokens/OUT.json
@@ -842,7 +842,7 @@
   {
     "address": "0x2dC99af320BC317c567f24eE95811dcbd5983DfD",
     "chainId": 4663,
-    "logoURI": "Please use existing logo URL",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/18834/large/wstETH.png?1696518295",
     "decimals": 18,
     "name": "wstETH",
     "symbol": "wstETH"


### PR DESCRIPTION
## Summary

Fixes the non-resolving logo for **wstETH** on **Robinhood chain (4663)**.

The custom-list entry had its `logoURI` set to the literal placeholder string **`"Please use existing logo URL"`** (not a URL), which the API served verbatim — so the logo never resolved.

| Field | Value |
|-------|-------|
| Address | `0x2dC99af320BC317c567f24eE95811dcbd5983DfD` |
| Chain | Robinhood (`4663`) |
| Symbol / Name | wstETH / wstETH |
| Decimals | 18 |
| logoURI (before) | `Please use existing logo URL` ❌ |
| logoURI (after) | `https://coin-images.coingecko.com/coins/images/18834/large/wstETH.png?1696518295` ✅ |

## Verification

- **On-chain** (`rpc.mainnet.chain.robinhood.com`): `symbol()` = `wstETH`, `decimals()` = `18` — matches the entry.
- **New logo**: `HTTP 200`, `content-type: image/png`.
- Only the `logoURI` changed; address/name/symbol/decimals untouched.

After merge, the logo propagates within ~1h (custom-list cache TTL).

Made with [Cursor](https://cursor.com)