### PR TITLE
feat: add new sPRL2 on eth and base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -560,6 +560,14 @@
     "logoURI": "https://raw.githubusercontent.com/parallel-protocol/parallel-brand-kit/main/Tokens/PRL/sPRL.svg"
   },
   {
+    "name": "Stake 20WETH-80PRL Deposit Vault",
+    "address": "0xb22f5edbc62adcc093307025b8fdf75a0aa00e24",
+    "symbol": "sPRL2V2",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/parallel-protocol/parallel-brand-kit/main/Tokens/PRL/sPRL.svg"
+  },
+  {
     "name": "Yala Token",
     "address": "0xF970706063b7853877F39515C96932D49d5AC9Cd",
     "symbol": "YALA",

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -744,9 +744,17 @@
     "logoURI": "https://raw.githubusercontent.com/parallel-protocol/parallel-brand-kit/main/Tokens/PRL/sPRL.svg"
   },
   {
-    "name": "Stake 20WETH-80PRL Aura Deposit Vault ",
+    "name": "Stake 20WETH-80PRL Aura Deposit Vault",
     "address": "0xE8A2d848fE656E34A6caA35f375B42979e322135",
     "symbol": "sPRL2",
+    "chainId": 1,
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/parallel-protocol/parallel-brand-kit/main/Tokens/PRL/sPRL.svg"
+  },
+  {
+    "name": "Stake 20WETH-80PRL Deposit Vault",
+    "address": "0xa13bfa24b189271ac00b148be565d609ac847a4b",
+    "symbol": "sPRL2V2",
     "chainId": 1,
     "decimals": 18,
     "logoURI": "https://raw.githubusercontent.com/parallel-protocol/parallel-brand-kit/main/Tokens/PRL/sPRL.svg"


### PR DESCRIPTION

## Summary
We had to deploy a new sPRL2 contract due to Aura finance sunset.

## Source

- [X] JSON validates (CI will confirm)
- [ ] Logo URL is reachable and renders correctly
- [ ] Token contract address is checksummed and verified on the relevant block explorer
- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge
