### PR TITLE
feat: add ZAMA on ETH

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1182,5 +1182,13 @@
     "decimals": 18,
     "name": "SK hynix xStock",
     "symbol": "SKHYx"
+  },
+  {
+    "address": "0xA12CC123ba206d4031D1c7f6223D1C2Ec249f4f3",
+    "chainId": 1,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70921/large/zama.png?1764591992",
+    "decimals": 18,
+    "name": "Zama",
+    "symbol": "ZAMA"
   }
 ]


### PR DESCRIPTION
## Add token: ZAMA (Ethereum)

Restores **Zama (ZAMA)** to the Ethereum default token list.

| Field | Value |
|---|---|
| Name | Zama |
| Symbol | ZAMA |
| Address | `0xA12CC123ba206d4031D1c7f6223D1C2Ec249f4f3` |
| Chain | Ethereum (chainId 1) |
| Decimals | 18 |
| Logo | CoinGecko |

### Why
Reported by partner **Bron**. ZAMA disappeared from `/v1/tokens` and `/v1/connections` around **July 16 ~14:15 UTC**, even though it is verified (hypernative: accept), priced (~$0.04), and quotable in both directions.

Root cause: the token dropped off every curated upstream source the token-fetch job ingests, so its `origins` collapsed to a subset of `{User, FeeCollectors}` (`isUserAddedToken = true`). The bulk token list and connections endpoints exclude user-added tokens by design, while `/v1/token` and `/v1/quote` keep working on demand.

Adding ZAMA to this curated list gives it a non-User (`List`) origin, flipping `isUserAddedToken` back to `false` on the next fetch cycle and restoring it to `/v1/tokens` + `/v1/connections`.

Made with [Cursor](https://cursor.com)