### PR TITLE
fix(tokens): add renamed Nest vault shares (nALPHA, nOPAL) on ETH and Plume

### DIFF
--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1230,5 +1230,21 @@
     "decimals": 18,
     "name": "Staked USDp",
     "symbol": "sUSDp"
+  },
+  {
+    "address": "0x593cCcA4c4bf58b7526a4C164cEEf4003C6388db",
+    "chainId": 1,
+    "logoURI": "https://assets.plume.org/images/logos/nest/nALPHA/nALPHA-token.svg",
+    "decimals": 6,
+    "name": "Nest Alpha Vault",
+    "symbol": "nALPHA"
+  },
+  {
+    "address": "0x119Dd7dAFf816f29D7eE47596ae5E4bdC4299165",
+    "chainId": 1,
+    "logoURI": "https://assets.plume.org/images/logos/nest/nOPAL/nOPAL-token.svg",
+    "decimals": 6,
+    "name": "Nest BlackOpal LiquidStone II Vault",
+    "symbol": "nOPAL"
   }
 ]

--- a/tokens/PLU.json
+++ b/tokens/PLU.json
@@ -1,4 +1,3 @@
-
 [
   {
     "name": "Plume USD",
@@ -103,6 +102,13 @@
     "decimals": 18,
     "chainId": 98866,
     "logoURI": "https://assets.coingecko.com/coins/images/54592/standard/mmev_logo.png"
+  },
+  {
+    "address": "0x119Dd7dAFf816f29D7eE47596ae5E4bdC4299165",
+    "chainId": 98866,
+    "logoURI": "https://assets.plume.org/images/logos/nest/nOPAL/nOPAL-token.svg",
+    "decimals": 6,
+    "name": "Nest BlackOpal LiquidStone II Vault",
+    "symbol": "nOPAL"
   }
 ]
-


### PR DESCRIPTION
Nest renamed two vault share tokens (**nRWA → nALPHA**, **nLSTONE → nOPAL**). On-chain metadata is already updated on every deployment, but `/v1/token` still serves the pre-rename symbol for three `(chain, address)` rows — so a user holding the same vault on Ethereum and Plume sees it twice under two different names. Reported by a partner via Plume.

Opened as a **draft on purpose** — not to be merged yet, pending review.

### Current live state

| chain | address | live `/v1/token` | on-chain truth |
|---|---|---|---|
| Ethereum | `0x593cCcA4…` | `nRWA` / Nest RWA Vault | `nALPHA` / Nest Alpha Vault |
| Ethereum | `0x119Dd7dA…` | `nLSTONE` / Nest BlackOpal LiquidStone II Vault | `nOPAL` / same name |
| Plume | `0x119Dd7dA…` | `nLSTONE` / Nest BlackOpal LiquidStone II Vault | `nOPAL` / same name |
| Plume | `0x593cCcA4…` | `nALPHA` / Nest Alpha Vault ✅ | already correct |

Plume `nALPHA` is the only correct row **because it is already listed in this repo** — so this PR adds **three** entries, not four.

### Verification

`symbol()` / `name()` / `decimals()` read on-chain (Nest uses deterministic deployments, so the address is identical across chains):

```
ETH   0x593cCcA4… -> "nALPHA" / "Nest Alpha Vault"                    / 6
PLU   0x593cCcA4… -> "nALPHA" / "Nest Alpha Vault"                    / 6
ETH   0x119Dd7dA… -> "nOPAL"  / "Nest BlackOpal LiquidStone II Vault" / 6
PLU   0x119Dd7dA… -> "nOPAL"  / "Nest BlackOpal LiquidStone II Vault" / 6
```

Nest's own catalog agrees (`GET https://api.nest.credit/v1/vaults?live=true`): slug `nest-alpha-vault` → nALPHA, slug `nest-opal-vault` → nOPAL. Both logo URLs return 200. Addresses are checksummed; key order matches what `apply-token.mjs` emits.

`pnpm lint` clean, `pnpm test` 1818/1818 passing locally.

### After merge

The custom list is cached for 1h server-side (`CustomListOracle`, `ms('1h')`), so an admin `PATCH /v1/token` immediately after merging can still read the pre-merge list. Wait out the cache, then patch each of the three rows.

### Follow-up (not in this PR)

This list entry is a workaround; two backend issues make the rename invisible without it:

1. **On-chain metadata is ranked 8th.** In `defaultTokenOracles`, `OnChainStaticTokenOracle` sits behind Zapper and Debank, which are indexer caches. Zapper supports Ethereum and returns its own stale `symbol`, which is why patching alone did not fix these rows.
2. **Static metadata is write-once.** `inflateTokensProcessor` filters out every token that already has a StaticToken, and writes with `insertOne` (duplicate-key errors swallowed). There is no TTL and no metadata-refresh job — a rename can never be picked up automatically.

Also spotted while editing: `tokens/PLU.json` lists `nBASIS` at `0x0000000000000000000000000000000000000000` (the native-token sentinel). Latent, not currently live-visible — real address per Nest is `0x11113ff3a60c2450f4b22515cb760417259ee94b`. Left untouched here to keep this PR scoped.