### PR TITLE
Remove duplicate WOM token

### DIFF
--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -136,14 +136,6 @@
     "logoURI": "https://arbiscan.io/token/images/speraxtoken_32.png"
   },
   {
-    "name": "Wombat Token",
-    "address": "0x7B5EB3940021Ec0e8e463D5dBB4B7B09a89DDF96",
-    "symbol": "WOM",
-    "decimals": 18,
-    "chainId": 42161,
-    "logoURI": "https://bscscan.com/token/images/wombatex_32.png"
-  },
-  {
     "name": "Stably USD",
     "address": "0x097BF766E427F5CcD306F21Ba05632e0Be849B0E",
     "symbol": "USDS",


### PR DESCRIPTION
Remove the duplicate WOM token entry from `tokens/ARB.json` and keep the version using the CoinGecko logo URI.

The duplicate entries are located at:

Lines: [139–145](https://github.com/lifinance/customized-token-list/blob/main/tokens/ARB.json#L139-L145)
Lines [194–201](https://github.com/lifinance/customized-token-list/blob/main/tokens/ARB.json#L194-L201)
