### PR TITLE
feat: deny FoT tokens reported by Bitavo

### DIFF
--- a/denyTokens/ARB.json
+++ b/denyTokens/ARB.json
@@ -58,5 +58,10 @@
     "chainId": 42161,
     "address": "0x327006c8712FE0AbdbbD55B7999DB39b0967342E",
     "reason": "Scam fake PYUSD token"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xE43b45C34e654B1038ceCdB57A0302A788FEA3F5",
+    "reason": "Fee-on-transfer token (XRP20). Bitavo reports swap-out failures with transfer amount exceeds balance."
   }
 ]

--- a/denyTokens/BAS.json
+++ b/denyTokens/BAS.json
@@ -63,5 +63,10 @@
     "chainId": 8453,
     "address": "0x89F162f17B066f129F6E870067DC3Acc8F611D21",
     "reason": "Impersonates WETH on Base"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x051fb509e4A775FABd257611eeA1efaed8F91359",
+    "reason": "Fee-on-transfer token (CateCoin / CATE). Bitavo reports swap-out failures with transfer amount exceeds balance."
   }
 ]

--- a/denyTokens/BSC.json
+++ b/denyTokens/BSC.json
@@ -303,5 +303,15 @@
     "chainId": 56,
     "address": "0x68fa48B1C2FE52b3D776E1953e0E782b5044Ce28",
     "reason": "SPCXx (SpaceX xStock): extremely thin BSC liquidity vs oracle price from deeper chains. ~$250 BNB swap returned ~0.00023 SPCXx (~$0.03). https://bscscan.com/tx/0x96934144b99fea513bdb744aac0dd772310ee3923ce4c2a93569797055af5e57"
+  },
+  {
+    "chainId": 56,
+    "address": "0xE4FAE3Faa8300810C835970b9187c268f55D998F",
+    "reason": "Fee-on-transfer token (CateCoin / CATE). Bitavo reports swap-out failures with transfer amount exceeds balance."
+  },
+  {
+    "chainId": 56,
+    "address": "0x55ad16Bd573B3365f43A9dAeB0Cc66A73821b4a5",
+    "reason": "Fee-on-transfer token (OKZOO / AIOT). Bitavo reports swap-out failures with transfer amount exceeds balance."
   }
 ]

--- a/denyTokens/ETH.json
+++ b/denyTokens/ETH.json
@@ -388,5 +388,10 @@
     "chainId": 1,
     "address": "0xa6C5Ec3F4B31e37770aFE102540caC1b2AB004bc",
     "reason": "Airdrop/spam token with grossly inflated price feed (~$21K per token from a manipulated low-liquidity pool). Distorts partner fee dashboards. Deny until a reliable price source exists."
+  },
+  {
+    "chainId": 1,
+    "address": "0xE4aB0bE415e277d82C38625B72BD7DeA232C2E7d",
+    "reason": "Fee-on-transfer / deflationary token (XRP20, ~0.1% burn). Bitavo reports swap-out simulation failures with ERC20: transfer amount exceeds balance."
   }
 ]


### PR DESCRIPTION
## Summary
- Deny fee-on-transfer tokens that Bitavo reported: users can buy them, then swap-out simulation fails with `ERC20: transfer amount exceeds balance`.
- Tokens: XRP20 (ETH + Arbitrum), CateCoin/CATE (BSC + Base), OKZOO/AIOT (BSC).

## Source
- [x] **Partner / external request** — Bitavo (no GitHub issue). Slack: https://lifi-protocol.slack.com/archives/C0B2CGM3090/p1787075833102169

## Tokens

| Symbol | Name | Chain | Address |
|---|---|---|---|
| XRP20 | XRP20 | Ethereum (1) | `0xE4aB0bE415e277d82C38625B72BD7DeA232C2E7d` |
| XRP20 | XRP20 | Arbitrum (42161) | `0xE43b45C34e654B1038ceCdB57A0302A788FEA3F5` |
| CATE | CateCoin | BSC (56) | `0xE4FAE3Faa8300810C835970b9187c268f55D998F` |
| CATE | CateCoin | Base (8453) | `0x051fb509e4A775FABd257611eeA1efaed8F91359` |
| AIOT | OKZOO | BSC (56) | `0x55ad16Bd573B3365f43A9dAeB0Cc66A73821b4a5` |

Addresses confirmed via `/v1/token`. ETH XRP20 also confirmed in the thread with a failing sim (`transfer amount exceeds balance`). AIOT is no longer in `/v1/tokens` but `/v1/token` still returns it, so it is deny-listed to keep it from coming back.

## Checklist
- [x] JSON validates (CI will confirm)
- [x] Token contract address is checksummed and verified on the relevant block explorer
- [x] If this fulfils an external issue, the issue is linked above and will auto-close on merge


Made with [Cursor](https://cursor.com)