### PR TITLE
feat: add Monerium GBPe v2 tokens and mark v1 as [OLD] (partner: Monerium)

### DIFF
--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -638,5 +638,13 @@
     "decimals": 6,
     "name": "Ample Arbitrum XAUt0",
     "symbol": "aRXAUt0"
+  },
+  {
+    "address": "0x2D80dBf04D0802abD7A342DaFA5d7cB42bfbb52f",
+    "chainId": 42161,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBPe",
+    "symbol": "GBPe"
   }
 ]

--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -1174,5 +1174,13 @@
     "decimals": 18,
     "name": "Wrapped Vanguard Emerging Markets Stock Index Fund ST0x",
     "symbol": "wtVWO"
+  },
+  {
+    "address": "0xc4759Ed641DA77CbDc9fA2f37E9260a29BF7cC52",
+    "chainId": 8453,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBPe",
+    "symbol": "GBPe"
   }
 ]

--- a/tokens/DAI.json
+++ b/tokens/DAI.json
@@ -96,12 +96,12 @@
     "logoURI": "https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562"
   },
   {
-    "name": "Monerium GBP emoney",
+    "name": "Monerium GBP emoney [OLD]",
     "address": "0x5Cb9073902F2035222B9749F8fB0c9BFe5527108",
     "symbol": "GBPe",
     "decimals": 18,
     "chainId": 100,
-    "logoURI": "https://monerium.app/tokens/gbp/gbp.png"
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg"
   },
   {
     "address": "0x4b1E2c2762667331Bc91648052F646d1b0d35984",
@@ -144,14 +144,6 @@
     "logoURI": "https://assets.coingecko.com/coins/images/16509/standard/Circle_Orange_onWhite.png?1696516071"
   },
   {
-    "address": "0x5cb9073902f2035222b9749f8fb0c9bfe5527108",
-    "chainId": 100,
-    "symbol": "GBPe",
-    "decimals": 18,
-    "name": "Monerium GBP emoney",
-    "logoURI": "https://monerium.app/tokens/gbp/gbp.png"
-  },
-  {
     "name": "USDp",
     "address": "0x9eE1963f05553eF838604Dd39403be21ceF26AA4",
     "symbol": "USDp",
@@ -166,5 +158,13 @@
     "chainId": 100,
     "decimals": 2,
     "logoURI": "https://assets.coingecko.com/coins/images/34883/standard/IDRX_BLUE_COIN_200x200.png?1734983273"
+  },
+  {
+    "address": "0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053",
+    "chainId": 100,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBPe",
+    "symbol": "GBPe"
   }
 ]

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1270,5 +1270,13 @@
     "decimals": 6,
     "name": "Ample Ethereum XAUt",
     "symbol": "aEXAUt"
+  },
+  {
+    "address": "0x7ba92741Bf2A568abC6f1D3413c58c6e0244F8fD",
+    "chainId": 1,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBPe",
+    "symbol": "GBPe"
   }
 ]

--- a/tokens/LNA.json
+++ b/tokens/LNA.json
@@ -126,5 +126,13 @@
     "decimals": 6,
     "name": "Linea USD",
     "symbol": "USDL"
+  },
+  {
+    "address": "0x3Bce82cf1A2bc357F956dd494713Fe11DC54780f",
+    "chainId": 59144,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBPe",
+    "symbol": "GBPe"
   }
 ]

--- a/tokens/POL.json
+++ b/tokens/POL.json
@@ -366,5 +366,21 @@
     "decimals": 18,
     "name": "Saffron.finance",
     "symbol": "SFI"
+  },
+  {
+    "address": "0x75792CBDb361d80ba89271a079EfeE62c29FA324",
+    "chainId": 137,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBP emoney [OLD]",
+    "symbol": "GBPe"
+  },
+  {
+    "address": "0x646BEea7a02FdAdA34c8e118949fE32350aB2206",
+    "chainId": 137,
+    "logoURI": "https://docs.monerium.com/img/tokens/gbpe.svg",
+    "decimals": 18,
+    "name": "Monerium GBPe",
+    "symbol": "GBPe"
   }
 ]


### PR DESCRIPTION
Closes #712.

## Source
- **External request** — fulfils issue #712; partner: `Monerium`
- **Requested by:** @arnigudj (on behalf of `Monerium`)

## Summary
- Add current Monerium GBPe (v2) on Gnosis, Linea, Arbitrum, Base, Polygon, and Ethereum, with the official logo from [Monerium docs](https://docs.monerium.com/img/tokens/gbpe.svg).
- Label deprecated v1 contracts as `[OLD]` on Gnosis and Polygon so Jumper can distinguish them from v2.
- Remove a duplicate Gnosis v1 entry (`0x5cb9…` listed twice with different checksums).

## Verification
On-chain `name` / `symbol` / `decimals` and [api.monerium.app/tokens](https://api.monerium.app/tokens) all match the addresses below. Logo URL returns HTTP 200 (`image/svg+xml`).

| Chain | Address | On-chain name | Notes |
|---|---|---|---|
| Gnosis (100) | `0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053` | Monerium GBPe | v2 proxy |
| Linea (59144) | `0x3Bce82cf1A2bc357F956dd494713Fe11DC54780f` | Monerium GBPe | v2 proxy |
| Arbitrum (42161) | `0x2D80dBf04D0802abD7A342DaFA5d7cB42bfbb52f` | Monerium GBPe | v2 proxy |
| Base (8453) | `0xc4759Ed641DA77CbDc9fA2f37E9260a29BF7cC52` | Monerium GBPe | v2 proxy |
| Polygon (137) | `0x646BEea7a02FdAdA34c8e118949fE32350aB2206` | Monerium GBPe | v2 proxy |
| Ethereum (1) | `0x7ba92741Bf2A568abC6f1D3413c58c6e0244F8fD` | Monerium GBP emoney | Official current ETH GBPe per Monerium API. Listed as v2 in the issue; on-chain name is still the v1-style string. Display name in this list is `Monerium GBPe` as requested. |
| Gnosis v1 | `0x5Cb9073902F2035222B9749F8fB0c9BFe5527108` | Monerium GBP emoney | Already listed; renamed `[OLD]` |
| Polygon v1 | `0x75792CBDb361d80ba89271a079EfeE62c29FA324` | Monerium GBP emoney | Added as `[OLD]` |

### Issue correction — Ethereum v1
The issue listed Ethereum v1 `[OLD]` as `0x7ba92741…`, which is the same address as the current Ethereum GBPe. That is a copy-paste error, so it is **not** added a second time as `[OLD]`. The 2018 Ethereum GBP TokenFrontend (`0x01df10e3…`) is invalid / deny-listed and was not added either.

## Add / update entries
```
  tokens/DAI.json: + GBPe v2 (0x8E34bfEC4f6Eb781f9743D9b4af99CD23F9b7053, chainId 100)
  tokens/DAI.json: rename existing Gnosis v1 to Monerium GBP emoney [OLD]; drop duplicate
  tokens/LNA.json: + GBPe (0x3Bce82cf1A2bc357F956dd494713Fe11DC54780f, chainId 59144)
  tokens/ARB.json: + GBPe (0x2D80dBf04D0802abD7A342DaFA5d7cB42bfbb52f, chainId 42161)
  tokens/BAS.json: + GBPe (0xc4759Ed641DA77CbDc9fA2f37E9260a29BF7cC52, chainId 8453)
  tokens/POL.json: + GBPe v2 (0x646BEea7a02FdAdA34c8e118949fE32350aB2206, chainId 137)
  tokens/POL.json: + GBPe v1 [OLD] (0x75792CBDb361d80ba89271a079EfeE62c29FA324, chainId 137)
  tokens/ETH.json: + GBPe (0x7ba92741Bf2A568abC6f1D3413c58c6e0244F8fD, chainId 1)
```

## Test plan
- [x] JSON is valid
- [x] Logo URL is reachable
- [x] Addresses are checksummed and match on-chain + Monerium API
- [x] CI (`lint.yml` + `validate.yml`) green

Made with [Cursor](https://cursor.com)