### PR TITLE
chore: remove deprecated Monerium EURe v1 on ETH, POL, DAI

### DIFF
--- a/tokens/DAI.json
+++ b/tokens/DAI.json
@@ -88,14 +88,6 @@
     "logoURI": "https://fraction.fyi/static/FRACTION-TokenIcon-LIFI-256x256.png"
   },
   {
-    "name": "Monerium EUR emoney",
-    "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
-    "symbol": "EURe",
-    "decimals": 18,
-    "chainId": 100,
-    "logoURI": "https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562"
-  },
-  {
     "name": "Monerium GBP emoney [OLD]",
     "address": "0x5Cb9073902F2035222B9749F8fB0c9BFe5527108",
     "symbol": "GBPe",

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -208,14 +208,6 @@
     "logoURI": "https://assets.coingecko.com/coins/images/8472/small/MicrosoftTeams-image_%286%29.png?1674480131"
   },
   {
-    "name": "Monerium EUR emoney",
-    "address": "0x3231cb76718cdef2155fc47b5286d82e6eda273f",
-    "symbol": "EURe",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562"
-  },
-  {
     "name": "IPOR Token",
     "address": "0x1e4746dC744503b53b4A082cB3607B169a289090",
     "symbol": "IPOR",

--- a/tokens/POL.json
+++ b/tokens/POL.json
@@ -168,14 +168,6 @@
     "logoURI": "https://assets.coingecko.com/coins/images/8472/small/MicrosoftTeams-image_%286%29.png?1674480131"
   },
   {
-    "name": "Monerium EUR emoney",
-    "address": "0x18ec0a6e18e5bc3784fdd3a3634b31245ab704f6",
-    "symbol": "EURe",
-    "decimals": 18,
-    "chainId": 137,
-    "logoURI": "https://assets.coingecko.com/coins/images/23354/small/eur.png?1643926562"
-  },
-  {
     "name": "BetSwirl v2",
     "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
     "symbol": "BETS",


### PR DESCRIPTION
## What

Removes the 3 deprecated Monerium EURe v1 entries. The v2 contracts landed in #715 (issue #713).

| Chain | File | Removed address | On-chain name |
|---|---|---|---|
| Ethereum (1) | `tokens/ETH.json` | `0x3231Cb76718CDeF2155FC47b5286d82e6eDA273f` | Monerium EUR emoney |
| Polygon (137) | `tokens/POL.json` | `0x18ec0A6E18E5bc3784fDd3a3634b31245ab704F6` | Monerium EUR emoney |
| Gnosis (100) | `tokens/DAI.json` | `0xcB444e90D8198415266c6a2724b7900fb12FC56E` | Monerium EUR emoney |

## Why

Monerium migrated EURe to new v2 contracts. Requested by the partner in #713:

> We have V1 tokens on Gnosis, Polygon, and Ethereum that are deprecated and need to be either marked with [OLD] or removed from the list.

Keeping both means two `EURe` entries per chain in the token picker, and users can pick the deprecated one by mistake.

## Routing impact

No chain loses its `EURe` entry. Each of the three files keeps exactly one, the v2 contract added in #715:

- `tokens/ETH.json` -> `0x39b8B6385416f4cA36a20319F70D28621895279D`
- `tokens/POL.json` -> `0xE0aEa583266584DafBB3f9C3211d5588c73fEa8d`
- `tokens/DAI.json` -> `0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430`

The v1 contracts stay live on-chain and still price via Debank/Zerion, so a v1 balance remains swappable by passing the address directly to the API. This change only removes it from the default list.

## Note on consistency with GBPe

#714 handled the sibling Monerium GBPe migration by renaming v1 to `Monerium GBP emoney [OLD]` and keeping it listed, rather than removing it. This PR removes instead. Say the word if you would rather have EURe match the GBPe treatment, and I will switch it to an `[OLD]` rename.

## Validation

- `npx prettier --check tokens/DAI.json tokens/POL.json tokens/ETH.json` — passes
- `npx jest` — 1912 assertions pass

Made with [Cursor](https://cursor.com)