### PR TITLE
feat: add cbZEC and cbHYPE on BAS

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -1190,5 +1190,21 @@
     "decimals": 18,
     "name": "Monerium EURe",
     "symbol": "EURe"
+  },
+  {
+    "address": "0xB2000000000000000000008501b13360000cb2EC",
+    "chainId": 8453,
+    "logoURI": "https://i.imgur.com/kodfBhe.png",
+    "decimals": 8,
+    "name": "Coinbase Wrapped ZEC",
+    "symbol": "cbZEC"
+  },
+  {
+    "address": "0xB200000000000000000000451d033a5000cb479e",
+    "chainId": 8453,
+    "logoURI": "https://i.imgur.com/jO5BlIF.png",
+    "decimals": 18,
+    "name": "Coinbase Wrapped Hyperliquid",
+    "symbol": "cbHYPE"
   }
 ]


### PR DESCRIPTION
Adds the two Coinbase wrapped assets on Base (chainId 8453) to `tokens/BAS.json`.

| Symbol | Name | Address | Decimals |
|---|---|---|---|
| cbZEC | Coinbase Wrapped ZEC | [`0xB2000000000000000000008501b13360000cb2EC`](https://basescan.org/token/0xB2000000000000000000008501b13360000cb2EC) | 8 |
| cbHYPE | Coinbase Wrapped Hyperliquid | [`0xB200000000000000000000451d033a5000cb479e`](https://basescan.org/token/0xB200000000000000000000451d033a5000cb479e) | 18 |

## Verification

- `name`, `symbol`, and `decimals` read on-chain via `eth_call` against `https://mainnet.base.org`. Both match the values above.
- Both addresses pass EIP-55 checksum.
- Neither address is present in `denyTokens/BAS.json`.
- `npx jest` — 1914 assertions pass.
- `npx prettier --check tokens/BAS.json` — clean.
- Both `logoURI` values return HTTP 200 with `content-type: image/png`.

## Note

The on-chain `name()` for cbHYPE is `Coinbase Wrapped Hyperliquid`, not "Coinbase Wrapped Staked Hype". The on-chain value is used.

Made with [Cursor](https://cursor.com)