### PR TITLE
feat: deny 3 Orbit gateway wrappers on Robinhood

### DIFF
--- a/denyTokens/OUT.json
+++ b/denyTokens/OUT.json
@@ -13,5 +13,20 @@
     "chainId": 4663,
     "address": "0xf46EC39A058E4FD98c4a32cdFaF09c8250eB9045",
     "reason": "Honeypot"
+  },
+  {
+    "chainId": 4663,
+    "address": "0x8124dc4802d5D68FC848f6997cA4E7bE125a78E9",
+    "reason": "Orbit standard-gateway wrapper of Ethereum VIRTUAL, not the official Robinhood Chain VIRTUAL (0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31). No price feed and almost no liquidity, so routing sold 1622 units for $24 in tx 0x2d3da35aa9738c56b4bc1faded7d31e514bb3a436c25d5ef63a7455ec100dd72. Holders must withdraw through the native bridge instead."
+  },
+  {
+    "chainId": 4663,
+    "address": "0x0822560CBDB92a0Af70397379ddb4Dcc4C95C8a7",
+    "reason": "Orbit standard-gateway wrapper of Ethereum LINK, not the official Robinhood Chain LINK (0x492641F648a4986844848E0beFE66D14817bCE34). No price feed and no liquidity."
+  },
+  {
+    "chainId": 4663,
+    "address": "0xcD26A6AA5BB008240A998E242F51232FE98B12Cb",
+    "reason": "Orbit standard-gateway wrapper of Ethereum wstETH, not the official Robinhood Chain wstETH (0x2dC99af320BC317c567f24eE95811dcbd5983DfD). No price feed and no liquidity."
   }
 ]


### PR DESCRIPTION
## What

Denies three tokens on Robinhood Chain (4663) in `denyTokens/OUT.json`:

| Symbol | Denied wrapper | Official token that stays listed |
|---|---|---|
| VIRTUAL | `0x8124dc4802d5D68FC848f6997cA4E7bE125a78E9` | `0xc6911796042b15d7Fa4F6CDe69e245DdCd3d9c31` |
| LINK | `0x0822560CBDB92a0Af70397379ddb4Dcc4C95C8a7` | `0x492641F648a4986844848E0beFE66D14817bCE34` |
| wstETH | `0xcD26A6AA5BB008240A998E242F51232FE98B12Cb` | `0x2dC99af320BC317c567f24eE95811dcbd5983DfD` |

## Why

The Arbitrum Orbit standard gateway deploys an L2 wrapper for any L1 ERC20 on first deposit. The token issuer is not involved, so these wrappers never appear on a project's official address list, yet they carry the same symbol as the officially listed token on the same chain.

None of them has a price feed. They fall through to the `MinimalPriceOracle` sentinel of `0.0000000001`, which makes `fromAmountUSD` about `$0.0001`. That is below the `NO_PERCENTAGE_DIFFERENCE_BELOW_USD = '10'` gate in `routePriceImpactFilter`, so the 10% price-impact check is skipped and an economically invalid route is published.

A user hit this on VIRTUAL and lost 97.9% of their position:

- Tx: [`0x2d3da35a…c100dd72`](https://scan.li.fi/tx/0x2d3da35aa9738c56b4bc1faded7d31e514bb3a436c25d5ef63a7455ec100dd72)
- Sent 1622.5582 wrapper VIRTUAL, received **34.7120** VIRTUAL on Ethereum (~$24.37).
- Same size quoted with the official `0xc691…` token returns **1594.1671** VIRTUAL, a 1.8% cost.
- The reverse direction is already blocked correctly, because there `fromAmountUSD` clears the $10 gate: `"Price impact of 99.99956999419493% is higher than the max allowed 10%"`.

The bridge and destination legs behaved correctly. The user received slightly more than `toAmountMin`. All value was lost in the source swap.

## Evidence that these are gateway wrappers, not scam tokens

```
0x8124dc…5a78E9 . l1Address()                       = 0x44ff8620…a091bf73  (Ethereum VIRTUAL)
0xfd9b1720…cb31e . calculateL2TokenAddress(0x44ff…) = 0x8124dc…5a78E9
0xfd9b1720…cb31e . counterpartGateway()             = 0x85001cc4…9e2a06da0
```

Both mints came from `0x96111cc4867c5e1c22da4b79bb8852b9e2a07eb1`, which is the Arbitrum address alias of the L1 gateway (`0x85001cc4…06da0 + 0x1111…1111`). The L1 gateway escrows 1718.4143 VIRTUAL against an L2 supply of 1708.4143, the 10.0 difference being a withdrawal in the challenge window.

So the tokens are genuinely backed and redeemable 1:1 through the native bridge. They are simply not tradable. Denying them returns "no route" and pushes holders to the native-bridge withdrawal, which is the correct remedy.

## Routing impact

None for the affected symbols. The official VIRTUAL, LINK and wstETH on chain 4663 remain listed and priced, so this does not remove the only entry for any symbol.

## Scope

I derived every standard-gateway wrapper on chain 4663 that collides with an officially listed token, using `calculateL2TokenAddress` across the 36 symbols listed on both Ethereum and 4663. These three are the only ones with non-zero supply, roughly $1,528 in total. This closes the current exposure.

It does not fix the class of bug. The `$10` gate still lets any sentinel-priced token skip the price-impact check on every chain, and the gateway deploys a new wrapper permissionlessly whenever anyone deposits a new L1 token. A follow-up in `lifi-backend` should reject routes whose endpoint carries the `MinimalPriceOracle` sentinel price.

## Test plan

- [x] `npx prettier --check denyTokens/OUT.json`
- [x] `npx jest` — 1921 assertions pass
- [ ] After merge, confirm `/v1/quote` with `fromToken=0x8124dc…` on chain 4663 returns no route (deny list refreshes on a 30 minute cache)

Made with [Cursor](https://cursor.com)