### PR TITLE
feat: Add VUSD,sVUSD,VetBTC,sVetBTC tokens

### DIFF
--- a/tokens/ARB.json
+++ b/tokens/ARB.json
@@ -646,5 +646,37 @@
     "decimals": 18,
     "name": "Monerium GBPe",
     "symbol": "GBPe"
+  },
+  {
+    "name": "Vetro USD",
+    "address": "0xCE2c108fB49551f6d27BBb529Ad1938835ac3574",
+    "symbol": "VUSD",
+    "decimals": 18,
+    "chainId": 42161,
+    "logoURI": "https://static.vetro.org/brand/tokens/VUSD/vetro-token-VUSD.png"
+  },
+  {
+    "name": "Staked Vetro USD",
+    "address": "0x50c580227764b621c0433bB6Ab756C781c495ce7",
+    "symbol": "sVUSD",
+    "decimals": 18,
+    "chainId": 42161,
+    "logoURI": "https://static.vetro.org/brand/tokens/sVUSD-VUSDx/vetro-token-sVUSD-VUSDx.png"
+  },
+  {
+    "name": "Vetro BTC",
+    "address": "0x0b874b240eF6D9d9543dBDEB224CDDC4BA71FD0f",
+    "symbol": "vetBTC",
+    "decimals": 18,
+    "chainId": 42161,
+    "logoURI": "https://static.vetro.org/brand/tokens/vetBTC/vetro-token-vetBTC.png"
+  },
+  {
+    "name": "Staked Vetro BTC",
+    "address": "0x54181404A037757eb5271Ee4a02CA51844f25eaA",
+    "symbol": "svetBTC",
+    "decimals": 18,
+    "chainId": 42161,
+    "logoURI": "https://static.vetro.org/brand/tokens/svetBTC-vetBTCx/vetro-token-svetBTC-vetBTCx.png"
   }
 ]

--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -1206,5 +1206,37 @@
     "decimals": 18,
     "name": "Coinbase Wrapped Hyperliquid",
     "symbol": "cbHYPE"
+  },
+  {
+    "name": "Vetro USD",
+    "address": "0x8a654093e21703afc8d038FF253A3c974C5C2957",
+    "symbol": "VUSD",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://static.vetro.org/brand/tokens/VUSD/vetro-token-VUSD.png"
+  },
+  {
+    "name": "Staked Vetro USD",
+    "address": "0xb174750002068862Dfe7DF38F974a950F189386a",
+    "symbol": "sVUSD",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://static.vetro.org/brand/tokens/sVUSD-VUSDx/vetro-token-sVUSD-VUSDx.png"
+  },
+  {
+    "name": "Vetro BTC",
+    "address": "0x605EDFDA1EA02cE9d2d2702e31064867F67aF043",
+    "symbol": "vetBTC",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://static.vetro.org/brand/tokens/vetBTC/vetro-token-vetBTC.png"
+  },
+  {
+    "name": "Staked Vetro BTC",
+    "address": "0x781aea37b81F3CF3Fb9a97E9568BdAF36d2DEF3d",
+    "symbol": "svetBTC",
+    "decimals": 18,
+    "chainId": 8453,
+    "logoURI": "https://static.vetro.org/brand/tokens/svetBTC-vetBTCx/vetro-token-svetBTC-vetBTCx.png"
   }
 ]

--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -2054,5 +2054,37 @@
     "decimals": 18,
     "name": "Moderna xStock",
     "symbol": "MRNAx"
+  },
+  {
+    "name": "Vetro USD",
+    "address": "0x10061d0593441Ff74536158592e1Be3F4C7B180C",
+    "symbol": "VUSD",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://static.vetro.org/brand/tokens/VUSD/vetro-token-VUSD.png"
+  },
+  {
+    "name": "Staked Vetro USD",
+    "address": "0xC141B66eE4262Ba46Ea29578955C274fD4A96515",
+    "symbol": "sVUSD",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://static.vetro.org/brand/tokens/sVUSD-VUSDx/vetro-token-sVUSD-VUSDx.png"
+  },
+  {
+    "name": "Vetro BTC",
+    "address": "0xD46ac62F9C145B64146AFadB848476B209b6b420",
+    "symbol": "vetBTC",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://static.vetro.org/brand/tokens/vetBTC/vetro-token-vetBTC.png"
+  },
+  {
+    "name": "Staked Vetro BTC",
+    "address": "0x37D8C0AFeeF48AA9D925475CF6c73E4D8c74d931",
+    "symbol": "svetBTC",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://static.vetro.org/brand/tokens/svetBTC-vetBTCx/vetro-token-svetBTC-vetBTCx.png"
   }
 ]

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1294,5 +1294,37 @@
     "decimals": 18,
     "name": "Apyx Treasury USD unstaked",
     "symbol": "alqUSD"
+  },
+  {
+    "name": "Vetro USD",
+    "address": "0xCa83DDE9c22254f58e771bE5E157773212AcBAc3",
+    "symbol": "VUSD",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://static.vetro.org/brand/tokens/VUSD/vetro-token-VUSD.png"
+  },
+  {
+    "name": "Staked Vetro USD",
+    "address": "0x476310E34D2810f7d79C43A74E4D79405bd7a925",
+    "symbol": "sVUSD",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://static.vetro.org/brand/tokens/sVUSD-VUSDx/vetro-token-sVUSD-VUSDx.png"
+  },
+  {
+    "name": "Vetro BTC",
+    "address": "0xf196C68233464A16CFDa319a47c21f4cECa62001",
+    "symbol": "vetBTC",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://static.vetro.org/brand/tokens/vetBTC/vetro-token-vetBTC.png"
+  },
+  {
+    "name": "Staked Vetro BTC",
+    "address": "0x0cB9D84d4bcEc8d3D5B2d99a6F07f4605325987e",
+    "symbol": "svetBTC",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://static.vetro.org/brand/tokens/svetBTC-vetBTCx/vetro-token-svetBTC-vetBTCx.png"
   }
 ]

--- a/tokens/HMI.json
+++ b/tokens/HMI.json
@@ -6,5 +6,37 @@
     "chainId": 43111,
     "decimals": 8,
     "logoURI": "https://storage.googleapis.com/merkl-static-assets/tokens/hemiBTC.svg"
+  },
+  {
+    "name": "Vetro USD",
+    "address": "0xD3599AE62EE280709A22268a46d23164214e345B",
+    "symbol": "VUSD",
+    "chainId": 43111,
+    "decimals": 18,
+    "logoURI": "https://static.vetro.org/brand/tokens/VUSD/vetro-token-VUSD.png"
+  },
+  {
+    "name": "Staked Vetro USD",
+    "address": "0xfe875CC86cC6BC2E93ab330D6b2c408C3Cd79710",
+    "symbol": "sVUSD",
+    "chainId": 43111,
+    "decimals": 18,
+    "logoURI": "https://static.vetro.org/brand/tokens/sVUSD-VUSDx/vetro-token-sVUSD-VUSDx.png"
+  },
+  {
+    "name": "Vetro BTC",
+    "address": "0xfF16E26B7fFCf24c378D57DF536dC5eC104a7dE4",
+    "symbol": "vetBTC",
+    "chainId": 43111,
+    "decimals": 18,
+    "logoURI": "https://static.vetro.org/brand/tokens/vetBTC/vetro-token-vetBTC.png"
+  },
+  {
+    "name": "Staked Vetro BTC",
+    "address": "0xD8D63De3b64bd06d99F8F5AD8B78Ed2fE7525eC0",
+    "symbol": "svetBTC",
+    "chainId": 43111,
+    "decimals": 18,
+    "logoURI": "https://static.vetro.org/brand/tokens/svetBTC-vetBTCx/vetro-token-svetBTC-vetBTCx.png"
   }
 ]

--- a/tokens/OPT.json
+++ b/tokens/OPT.json
@@ -214,5 +214,37 @@
     "decimals": 18,
     "name": "Moderna xStock",
     "symbol": "MRNAx"
+  },
+  {
+    "name": "Vetro USD",
+    "address": "0xb591169E6508983CC6618738cC73c9F09c38dE14",
+    "symbol": "VUSD",
+    "decimals": 18,
+    "chainId": 10,
+    "logoURI": "https://static.vetro.org/brand/tokens/VUSD/vetro-token-VUSD.png"
+  },
+  {
+    "name": "Staked Vetro USD",
+    "address": "0x92273Ca3356379C2fe870FE3805cc5e7aB6d19c6",
+    "symbol": "sVUSD",
+    "decimals": 18,
+    "chainId": 10,
+    "logoURI": "https://static.vetro.org/brand/tokens/sVUSD-VUSDx/vetro-token-sVUSD-VUSDx.png"
+  },
+  {
+    "name": "Vetro BTC",
+    "address": "0x974af4a481895FB9A29829F87980088f6B93E1DF",
+    "symbol": "vetBTC",
+    "decimals": 18,
+    "chainId": 10,
+    "logoURI": "https://static.vetro.org/brand/tokens/vetBTC/vetro-token-vetBTC.png"
+  },
+  {
+    "name": "Staked Vetro BTC",
+    "address": "0x62D2A7D31e8a61a7aCD472c98c657E053EB01b96",
+    "symbol": "svetBTC",
+    "decimals": 18,
+    "chainId": 10,
+    "logoURI": "https://static.vetro.org/brand/tokens/svetBTC-vetBTCx/vetro-token-svetBTC-vetBTCx.png"
   }
 ]


### PR DESCRIPTION
<!--
  PRs are restricted to members of @lifinance/fullstack and @lifinance/techsupport.
  External contributors: please open an issue using the "Add a token" template instead.
  See README.md for the full process.
-->

## Summary

<!-- One line: what is this PR adding / changing? -->

This PR adds the following tokens for Vetro protocol:

- [VUSD](https://etherscan.io/address/0xCa83DDE9c22254f58e771bE5E157773212AcBAc3)
- [sVUSD](https://etherscan.io/address/0x476310E34D2810f7d79C43A74E4D79405bd7a925)
- [VetBTC](https://etherscan.io/address/0x63413dA01EE7E1cec9d51EE27B3FAf81d786821c)
- [SVetBTC](https://etherscan.io/address/0x010F0Bd6576949e6ac6eEa11Ed8C535388340e94)

Additionally, their OFT counterparts in Hemi, OP, Arbitrum, BNB, and Base are added

## Source

<!-- Required. Pick one and fill in the details. -->

https://github.com/vetro-protocol/vetro-contracts/issues/111

- [ ] **Internal request** — added by an internal team member (no upstream issue)
- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`

## Checklist

- [x] JSON validates (CI will confirm)
- [x] Logo URL is reachable and renders correctly
- [x] Token contract address is checksummed and verified on the relevant block explorer
- [ ] If this fulfils an external issue, the issue is linked above and will auto-close on merge
