### PR TITLE
feat(tokens): add logos for 1044 Ondo GM tokens on ETH, BSC, SOL, HYP

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -552,7 +552,7 @@
     "logoURI": "https://assets.coingecko.com/coins/images/68596/standard/spgion_160x160.png"
   },
   {
-    "name": "Petróleo Brasileiro S.A.",
+    "name": "Petr\u00f3leo Brasileiro S.A.",
     "address": "0x2b1d5cdecc356530a746c5754231efaeaca64022",
     "symbol": "PBRon",
     "chainId": 56,
@@ -2066,9 +2066,2569 @@
   {
     "address": "0x290A5779a419Cb9cB22fa087CDD1CD16dA2D95F1",
     "chainId": 56,
-    "logoURI": "https://pc.am/brand/wpcn-round-256.png\n\n(256×256 PNG, transparent background, served from our own domain — permanent, no signing or expiry. An SVG source is at https://pc.am/brand/wpcn-round.svg and 32/64/128/512 px variants exist at the same path pattern.)",
+    "logoURI": "https://pc.am/brand/wpcn-round-256.png\n\n(256\u00d7256 PNG, transparent background, served from our own domain \u2014 permanent, no signing or expiry. An SVG source is at https://pc.am/brand/wpcn-round.svg and 32/64/128/512 px variants exist at the same path pattern.)",
     "decimals": 8,
     "name": "Wrapped PCoin",
     "symbol": "wPCN"
+  },
+  {
+    "name": "Ondo U.S. Dollar Token",
+    "address": "0x1f8955E640Cbd9abc3C3Bb408c9E2E1f5F20DfE6",
+    "symbol": "USDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usdon_160x160.png"
+  },
+  {
+    "name": "AbbVie (Ondo Tokenized)",
+    "address": "0x8677abad7b458bf16a0fb2676dfc7d3f55ac202a",
+    "symbol": "ABBVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abbvon_160x160.png"
+  },
+  {
+    "name": "Airbnb (Ondo Tokenized)",
+    "address": "0xef80743f78d98fc2b47a2253b293152ce8b879ba",
+    "symbol": "ABNBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abnbon_160x160.png"
+  },
+  {
+    "name": "Abbott (Ondo Tokenized)",
+    "address": "0x5a20886b575058dd7299785f0ea9b1172942a3e0",
+    "symbol": "ABTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abton_160x160.png"
+  },
+  {
+    "name": "Accenture (Ondo Tokenized)",
+    "address": "0x7af44d51d1fb88c5b74fc71d3cba649bb8099d14",
+    "symbol": "ACNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/acnon_160x160.png"
+  },
+  {
+    "name": "Adobe (Ondo Tokenized)",
+    "address": "0xcb22db0ecb6fe58b7b47db443dcfdfdfbf729cef",
+    "symbol": "ADBEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/adbeon_160x160.png"
+  },
+  {
+    "name": "Analog Devices (Ondo Tokenized)",
+    "address": "0x0e246e05212dbbd78a354c072a92b4e5723b2fa0",
+    "symbol": "ADIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/adion_160x160.png"
+  },
+  {
+    "name": "Albemarle (Ondo Tokenized)",
+    "address": "0x0B790ABd6594918DE1022233b7cc79baDB84d92a",
+    "symbol": "ALBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/albon_160x160.png"
+  },
+  {
+    "name": "Applied Materials (Ondo Tokenized)",
+    "address": "0x5ecc352c4640f1d26bd231dbbd171f40f7d0eec6",
+    "symbol": "AMATon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amaton_160x160.png"
+  },
+  {
+    "name": "AMC Entertainment (Ondo Tokenized)",
+    "address": "0x1d7b5e06fdbe4fd33f5c64c081e32b5d539751d0",
+    "symbol": "AMCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amcon_160x160.png"
+  },
+  {
+    "name": "Arista Networks (Ondo Tokenized)",
+    "address": "0x538e2838f9ebc9b891399df4a8dcc42890d9dc20",
+    "symbol": "ANETon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aneton_160x160.png"
+  },
+  {
+    "name": "Applied Digital (Ondo Tokenized)",
+    "address": "0x18De24acb876C0B8392d9C55583Bb21c0355980b",
+    "symbol": "APLDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/apldon_160x160.png"
+  },
+  {
+    "name": "Apollo Global Management (Ondo Tokenized)",
+    "address": "0x5630b5741a33371d9d935283849a16dc808f7f3a",
+    "symbol": "APOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/apoon_160x160.png"
+  },
+  {
+    "name": "AppLovin (Ondo Tokenized)",
+    "address": "0xedb3124e96c64c177eb709cbc64f9977db40ea74",
+    "symbol": "APPon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/appon_160x160.png"
+  },
+  {
+    "name": "Arm Holdings plc (Ondo Tokenized)",
+    "address": "0x527c6436e1eaa4f2065cde4090f798cb5d031dd6",
+    "symbol": "ARMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/armon_160x160.png"
+  },
+  {
+    "name": "AST SpaceMobile (Ondo Tokenized)",
+    "address": "0x45Abf29515bc23F8c0Ed2a06584444cE473A75FB",
+    "symbol": "ASTSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/astson_160x160.png"
+  },
+  {
+    "name": "American Express (Ondo Tokenized)",
+    "address": "0xd803f8777187d6dee1ea57854aeb957043fb1675",
+    "symbol": "AXPon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/axpon_160x160.png"
+  },
+  {
+    "name": "Bank of America (Ondo Tokenized)",
+    "address": "0xd615468088b19fb9d4f03cb3ce9e33876ff3db99",
+    "symbol": "BACon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bacon_160x160.png"
+  },
+  {
+    "name": "BigBear.ai Holdings (Ondo Tokenized)",
+    "address": "0x7ba995f1662a01f3be0dc299ce94bb7e9c7075f5",
+    "symbol": "BBAIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bbaion_160x160.png"
+  },
+  {
+    "name": "Bilibili (Ondo Tokenized)",
+    "address": "0x91fc7371d6de682a1e8cfcb4eb7da693312a03a4",
+    "symbol": "BILIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bilion_160x160.png"
+  },
+  {
+    "name": "iShares Flexible Income Active ETF (Ondo Tokenized)",
+    "address": "0x940f442746d9ae699e63c378d52c4494ea02684f",
+    "symbol": "BINCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bincon_160x160.png"
+  },
+  {
+    "name": "Blackrock, Inc. (Ondo Tokenized)",
+    "address": "0x24f5471183ea549987f245d6ce236b6108869c92",
+    "symbol": "BLKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blkon_160x160.png"
+  },
+  {
+    "name": "Bullish (Ondo Tokenized)",
+    "address": "0xfbe22d27b6e153244882fd7bdfe7c6109918281b",
+    "symbol": "BLSHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blshon_160x160.png"
+  },
+  {
+    "name": "US Brent Oil Fund (Ondo Tokenized)",
+    "address": "0x5f2d37192576a6804F44722eB828E280D5FB43Dc",
+    "symbol": "BNOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bnoon_160x160.png"
+  },
+  {
+    "name": "B2Gold (Ondo Tokenized)",
+    "address": "0xe2ac868f2fd097086d83bc939248e5ae08d35da4",
+    "symbol": "BTGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btgon_160x160.png"
+  },
+  {
+    "name": "BitGo Holdings (Ondo Tokenized)",
+    "address": "0x5fA699c0c1319b8D86489AF77dFDe4Fa97B47DF8",
+    "symbol": "BTGOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btgoon_160x160.png"
+  },
+  {
+    "name": "Kanzhun (Ondo Tokenized)",
+    "address": "0xc2c7fcddc37f6737ca2481ebda6b81ee279fe20c",
+    "symbol": "BZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bzon_160x160.png"
+  },
+  {
+    "name": "Capricor Therapeutics (Ondo Tokenized)",
+    "address": "0x812Fc2943371C952c6c8Daf99Fe665Eb0e40Cd27",
+    "symbol": "CAPRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/capron_160x160.png"
+  },
+  {
+    "name": "First Trust NASDAQ Cybersecurity ETF (Ondo Tokenized)",
+    "address": "0xDcd4536508060dab8F43C334B3a6C72c39528DA5",
+    "symbol": "CIBRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cibron_160x160.png"
+  },
+  {
+    "name": "VanEck CLO ETF (Ondo Tokenized)",
+    "address": "0xd7e3317d54473dab04135fb0676623f237ff5ca9",
+    "symbol": "CLOIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cloion_160x160.png"
+  },
+  {
+    "name": "Coherent (Ondo Tokenized)",
+    "address": "0x0585756aAFB241b0f8A9Df62Db26c566091Bde0b",
+    "symbol": "COHRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cohron_160x160.png"
+  },
+  {
+    "name": "ConocoPhillips (Ondo Tokenized)",
+    "address": "0x0d586b51a90dc999f9bb6a0506da7f034a1d3a2e",
+    "symbol": "COPon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/copon_160x160.png"
+  },
+  {
+    "name": "Costco (Ondo Tokenized)",
+    "address": "0x34375f826fd3dd4e15f883d4f4786bb45eb705ac",
+    "symbol": "COSTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coston_160x160.png"
+  },
+  {
+    "name": "Coupang (Ondo Tokenized)",
+    "address": "0x19904bc04c09e5d29ed216ddd105bdf103a0ba2d",
+    "symbol": "CPNGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cpngon_160x160.png"
+  },
+  {
+    "name": "CoreWeave (Ondo Tokenized)",
+    "address": "0x76E39171Cb665a35981e744e2CEB7012F76caEAc",
+    "symbol": "CRWVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crwvon_160x160.png"
+  },
+  {
+    "name": "Carvana (Ondo Tokenized)",
+    "address": "0xc145dc2ebdbe8ead1fecdebf46c76eb1fdd0104d",
+    "symbol": "CVNAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cvnaon_160x160.png"
+  },
+  {
+    "name": "Chevron (Ondo Tokenized)",
+    "address": "0xd3113a0ad20a46f6a662c63fe8e637f7713e59c7",
+    "symbol": "CVXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cvxon_160x160.png"
+  },
+  {
+    "name": "DoorDash (Ondo Tokenized)",
+    "address": "0x7567c2a46bce46373b454682f3d95e6535bde144",
+    "symbol": "DASHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dashon_160x160.png"
+  },
+  {
+    "name": "Invesco DB Commodity Index Tracking Fund (Ondo Tokenized)",
+    "address": "0xfc2067e3e6a289c205151d96ef67a032f339566d",
+    "symbol": "DBCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dbcon_160x160.png"
+  },
+  {
+    "name": "Deere (Ondo Tokenized)",
+    "address": "0x90ccbb75d61cb65cd73a3abb5df04a75961612b7",
+    "symbol": "DEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/deon_160x160.png"
+  },
+  {
+    "name": "WisdomTree US Quality Dividend Growth Fund (Ondo Tokenized)",
+    "address": "0x1cd89241b26fcdc421fd02907d6504c8abbfe1bc",
+    "symbol": "DGRWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dgrwon_160x160.png"
+  },
+  {
+    "name": "Disney (Ondo Tokenized)",
+    "address": "0xeee9eee593cb8f7946260b4066cba7907f40acfa",
+    "symbol": "DISon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dison_160x160.png"
+  },
+  {
+    "name": "Denison Mines (Ondo Tokenized)",
+    "address": "0x70bd780076e25d087ed9c35f4e4a540522abe8cf",
+    "symbol": "DNNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dnnon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Chile ETF (Ondo Tokenized)",
+    "address": "0x551f8Db0da800C910E12Cf991eac306714481685",
+    "symbol": "ECHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/echon_160x160.png"
+  },
+  {
+    "name": "Enlivex Therapeutics (Ondo Tokenized)",
+    "address": "0x5A9D924FC336A5EC8cf3B1909aA660533B50b015",
+    "symbol": "ENLVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enlvon_160x160.png"
+  },
+  {
+    "name": "Enphase Energy (Ondo Tokenized)",
+    "address": "0x30938154E2697694F41592C2e48459287dEBe4BF",
+    "symbol": "ENPHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enphon_160x160.png"
+  },
+  {
+    "name": "Equinix (Ondo Tokenized)",
+    "address": "0xe4e12c9cec3e8cae405202a97f66afa695075fa0",
+    "symbol": "EQIXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/eqixon_160x160.png"
+  },
+  {
+    "name": "iShares Ethereum Trust (Ondo Tokenized)",
+    "address": "0x04B16ff1F9673146F68AA5d5F57aA45AdcF068E1",
+    "symbol": "ETHAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ethaon_160x160.png"
+  },
+  {
+    "name": "Eaton (Ondo Tokenized)",
+    "address": "0x4697b2A050f7B5A8e1ebc27c325f9D78D094f041",
+    "symbol": "ETNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/etnon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Japan ETF (Ondo Tokenized)",
+    "address": "0x82715299f3f132FB85f3De1F7e8fAfd3d79f3eB5",
+    "symbol": "EWJon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewjon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI South Korea ETF (Ondo Tokenized)",
+    "address": "0x12B7aDC48416A103F63E7e6210f62C81dfB91fD0",
+    "symbol": "EWYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewyon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Brazil ETF (Ondo Tokenized)",
+    "address": "0x9876F4b879cDe9Aa49Ffd260034A0698B7B33A49",
+    "symbol": "EWZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewzon_160x160.png"
+  },
+  {
+    "name": "Exodus Movement (Ondo Tokenized)",
+    "address": "0x92d504158A8Dc69de989dB5EDe3230D958fb8630",
+    "symbol": "EXODon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/exodon_160x160.png"
+  },
+  {
+    "name": "Freeport-McMoRan (Ondo Tokenized)",
+    "address": "0xE3b17E6D290A0F28bd32aF4064637057627004D5",
+    "symbol": "FCXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fcxon_160x160.png"
+  },
+  {
+    "name": "Franklin Focused Growth ETF (Ondo Tokenized)",
+    "address": "0xEA130432a9feE9ca1A7eDa84028650d38Bd0E232",
+    "symbol": "FFOGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ffogon_160x160.png"
+  },
+  {
+    "name": "Franklin Responsibly Sourced Gold ETF (Ondo Tokenized)",
+    "address": "0xee0d57462f20434030B8262204c00c0eA0399C41",
+    "symbol": "FGDLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fgdlon_160x160.png"
+  },
+  {
+    "name": "Figma (Ondo Tokenized)",
+    "address": "0x93fac02b22b6743423381d163aec418178019b7a",
+    "symbol": "FIGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/figon_160x160.png"
+  },
+  {
+    "name": "Franklin High Yield Corporate ETF (Ondo Tokenized)",
+    "address": "0x240Eb4859B4537D250cf784cc758c404dA5Fe4bd",
+    "symbol": "FLHYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flhyon_160x160.png"
+  },
+  {
+    "name": "Franklin US Large Cap Multifactor Index ETF (Ondo Tokenized)",
+    "address": "0x48187890D16aEE64798E02C5BeD510f4dB5694A9",
+    "symbol": "FLQLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flqlon_160x160.png"
+  },
+  {
+    "name": "Fidelity Solana Fund (Ondo Tokenized)",
+    "address": "0x54B92Fd77229269Ff6484942C123cCa72f2D6fEC",
+    "symbol": "FSOLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fsolon_160x160.png"
+  },
+  {
+    "name": "First Trust Global Tactical Commodity Strategy Fund (Ondo Tokenized)",
+    "address": "0xe96f94e10f1265dcc15f83d251f1f6758d2cd67d",
+    "symbol": "FTGCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ftgcon_160x160.png"
+  },
+  {
+    "name": "Futu Holdings (Ondo Tokenized)",
+    "address": "0x5acf40056ed51c8bbcd1b125ef803581ac89a627",
+    "symbol": "FUTUon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/futuon_160x160.png"
+  },
+  {
+    "name": "iShares China Large-Cap ETF (Ondo Tokenized)",
+    "address": "0x9b8E987e6fEc8Cf1380C4dcA7071e2C7853AEEA1",
+    "symbol": "FXIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fxion_160x160.png"
+  },
+  {
+    "name": "Gemini Space Station (Ondo Tokenized)",
+    "address": "0x817942d5de16092656568e9f67f54ccb462f8989",
+    "symbol": "GEMIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gemion_160x160.png"
+  },
+  {
+    "name": "General Electric (Ondo Tokenized)",
+    "address": "0x5151a22421ed4277f1e4ca4785a07b035d548a36",
+    "symbol": "GEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/geon_160x160.png"
+  },
+  {
+    "name": "GE Vernova (Ondo Tokenized)",
+    "address": "0x2Aea1D415D45CCF3EaBE565d45DcaF4ea2035b9c",
+    "symbol": "GEVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gevon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Precious Metals Basket Shares ETF (Ondo Tokenized)",
+    "address": "0x15580092796f69825CFf4738Cac55D05D41eaa42",
+    "symbol": "GLTRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gltron_160x160.png"
+  },
+  {
+    "name": "Galaxy Digital (Ondo Tokenized)",
+    "address": "0xF98B89825233808CD37706A53D2b4Ae3e359d442",
+    "symbol": "GLXYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/glxyon_160x160.png"
+  },
+  {
+    "name": "Grab Holdings (Ondo Tokenized)",
+    "address": "0xab2f74804c022c5249d52e743af4340e42f5f3b6",
+    "symbol": "GRABon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/grabon_160x160.png"
+  },
+  {
+    "name": "Grindr (Ondo Tokenized)",
+    "address": "0x20cce48d767ed68cbba7727c4c504efe5bcb626c",
+    "symbol": "GRNDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/grndon_160x160.png"
+  },
+  {
+    "name": "Goldman Sachs (Ondo Tokenized)",
+    "address": "0x0d4f9b25f81163fb4840ba4f434672543823000c",
+    "symbol": "GSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gson_160x160.png"
+  },
+  {
+    "name": "Home Depot (Ondo Tokenized)",
+    "address": "0x31dabf49e4bc1af1456c1819cb6a2562154e92f3",
+    "symbol": "HDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hdon_160x160.png"
+  },
+  {
+    "name": "PIMCO 0-5 Year High Yield Corporate Bond Index ETF (Ondo Tokenized)",
+    "address": "0x75E9D68e99e76714ed1a7663ab48ba3AaBd7A6c5",
+    "symbol": "HYSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hyson_160x160.png"
+  },
+  {
+    "name": "iShares Bitcoin Trust (Ondo Tokenized)",
+    "address": "0x68B07cEf227Cea1b2b6683921C8c825cd5C69Ec7",
+    "symbol": "IBITon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ibiton_160x160.png"
+  },
+  {
+    "name": "iShares 7-10 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0xA486a0A05250E8621bA3B26C3bbc517145eba619",
+    "symbol": "IEFon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iefon_160x160.png"
+  },
+  {
+    "name": "Franklin Income Equity Focus ETF (Ondo Tokenized)",
+    "address": "0x5e24DB6DE4C21E2C8f9E81bAcfCedFBAC2DeE4aa",
+    "symbol": "INCEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inceon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI India ETF (Ondo Tokenized)",
+    "address": "0xdB0748297fbEf0B33dF89e86519A0BD3adAf6459",
+    "symbol": "INDAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/indaon_160x160.png"
+  },
+  {
+    "name": "Intuit (Ondo Tokenized)",
+    "address": "0x6e3e077a6c0e3c27fd6d00b97387d9b7bd451bab",
+    "symbol": "INTUon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/intuon_160x160.png"
+  },
+  {
+    "name": "IonQ (Ondo Tokenized)",
+    "address": "0x40d8E1fbaf69173c47fa493FeB50a84eeC6b57eE",
+    "symbol": "IONQon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ionqon_160x160.png"
+  },
+  {
+    "name": "Intuitive Surgical (Ondo Tokenized)",
+    "address": "0x784584933c2192caa062e90d8140d94768ce62d8",
+    "symbol": "ISRGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/isrgon_160x160.png"
+  },
+  {
+    "name": "iShares US Aerospace and Defense ETF (Ondo Tokenized)",
+    "address": "0x88B90f45bd6a4F97f7D85d280eD64A40880e4935",
+    "symbol": "ITAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/itaon_160x160.png"
+  },
+  {
+    "name": "Janus Henderson AAA CLO ETF (Ondo Tokenized)",
+    "address": "0x84719a1082ed487c7eeac7d69885e3cc2009ea78",
+    "symbol": "JAAAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jaaaon_160x160.png"
+  },
+  {
+    "name": "Johnson & Johnson (Ondo Tokenized)",
+    "address": "0xd1f799cb9f5d0a02951b0755beced6c43882712f",
+    "symbol": "JNJon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jnjon_160x160.png"
+  },
+  {
+    "name": "KraneShares CSI China Internet ETF (Ondo Tokenized)",
+    "address": "0x7437203800140BA7d9081ddE8cEF09EE40E3Bf03",
+    "symbol": "KWEBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/kwebon_160x160.png"
+  },
+  {
+    "name": "Lockheed (Ondo Tokenized)",
+    "address": "0xd09f7b75b9659b864c6f82bb00ff096f9d277998",
+    "symbol": "LMTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lmton_160x160.png"
+  },
+  {
+    "name": "Lowe's (Ondo Tokenized)",
+    "address": "0x2ec46eed30c94caa5979e6a0395abe824138335f",
+    "symbol": "LOWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lowon_160x160.png"
+  },
+  {
+    "name": "Lam Research (Ondo Tokenized)",
+    "address": "0x35895a1fa1aff7fb3204fb01257409fd75acb24c",
+    "symbol": "LRCXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lrcxon_160x160.png"
+  },
+  {
+    "name": "Intuitive Machines (Ondo Tokenized)",
+    "address": "0xA3b7B7cfEb023a6C4f444f5ca9a3Fc85809Ece15",
+    "symbol": "LUNRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lunron_160x160.png"
+  },
+  {
+    "name": "Mastercard (Ondo Tokenized)",
+    "address": "0x25ffda07f585c39848db6573e533d7585679c52d",
+    "symbol": "MAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/maon_160x160.png"
+  },
+  {
+    "name": "Merck (Ondo Tokenized)",
+    "address": "0x869027261075c3c239d6a26842579b93802606f4",
+    "symbol": "MRKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrkon_160x160.png"
+  },
+  {
+    "name": "Moderna (Ondo Tokenized)",
+    "address": "0x01486675da0764ee780ea7cb65c33062e9b2d28c",
+    "symbol": "MRNAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrnaon_160x160.png"
+  },
+  {
+    "name": "MicroStrategy (Ondo Tokenized)",
+    "address": "0x7313ea16493b2f55054df0131a3a14b043ec8992",
+    "symbol": "MSTRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mstron_160x160.png"
+  },
+  {
+    "name": "MasTec (Ondo Tokenized)",
+    "address": "0xf49046aae76eaeb7ffd3ef116ce0f7cd0f52d93e",
+    "symbol": "MTZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mtzon_160x160.png"
+  },
+  {
+    "name": "Nebius Group (Ondo Tokenized)",
+    "address": "0xee268780473E7a0e47baC41547C6E01512555A16",
+    "symbol": "NBISon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nbison_160x160.png"
+  },
+  {
+    "name": "Newmont (Ondo Tokenized)",
+    "address": "0x5E63232993789601CE362e0240a299C1DfCBfbEc",
+    "symbol": "NEMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nemon_160x160.png"
+  },
+  {
+    "name": "Sprott Nickel Miners ETF (Ondo Tokenized)",
+    "address": "0xe23f03d2907cdc38a10f6ccdc1a157bf1afe51de",
+    "symbol": "NIKLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/niklon_160x160.png"
+  },
+  {
+    "name": "Nike (Ondo Tokenized)",
+    "address": "0x04b5e199f2ec84f78b111035f57b16bee448db6f",
+    "symbol": "NKEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nkeon_160x160.png"
+  },
+  {
+    "name": "Northrop Grumman (Ondo Tokenized)",
+    "address": "0x4D3442D884202584F1729bCA20Db05472B886B52",
+    "symbol": "NOCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nocon_160x160.png"
+  },
+  {
+    "name": "ServiceNow (Ondo Tokenized)",
+    "address": "0xeb19c13c54b1cd48afc62f6503375e92d5f1e856",
+    "symbol": "NOWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nowon_160x160.png"
+  },
+  {
+    "name": "VanEck Oil Services ETF (Ondo Tokenized)",
+    "address": "0x31D6011023D6c7695Efc29bB016830F3F36De40a",
+    "symbol": "OIHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oihon_160x160.png"
+  },
+  {
+    "name": "ON Semiconductor (Ondo Tokenized)",
+    "address": "0xb35a9eab5d25282f4e668798b629a9294e9a47aa",
+    "symbol": "ONon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/onon_160x160.png"
+  },
+  {
+    "name": "Opera (Ondo Tokenized)",
+    "address": "0x88672043905bdd272df55a5a7bb1b7e1e693cbc5",
+    "symbol": "OPRAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/opraon_160x160.png"
+  },
+  {
+    "name": "Oscar Health (Ondo Tokenized)",
+    "address": "0xb0752aa50b089ee6ea9acd51373207fa460e87bb",
+    "symbol": "OSCRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oscron_160x160.png"
+  },
+  {
+    "name": "Occidental Petroleum (Ondo Tokenized)",
+    "address": "0x01b5a4ac600be98448dbefbb78bcdf38262552cc",
+    "symbol": "OXYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oxyon_160x160.png"
+  },
+  {
+    "name": "Global X US Infrastructure Development ETF (Ondo Tokenized)",
+    "address": "0x6f28Cb07790c1049ecd7482d09Fd13B977B47201",
+    "symbol": "PAVEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/paveon_160x160.png"
+  },
+  {
+    "name": "PG&E (Ondo Tokenized)",
+    "address": "0x47b36ddb9dd12a8411f78226f55e8c3f0d65481f",
+    "symbol": "PCGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pcgon_160x160.png"
+  },
+  {
+    "name": "Invesco Optimum Yld Dvsfd Cmd Str No K-1 ETF (Ondo Tokenized)",
+    "address": "0xcf3e84e62002ca459db81b2032d7fe13715bad51",
+    "symbol": "PDBCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pdbcon_160x160.png"
+  },
+  {
+    "name": "Procter & Gamble (Ondo Tokenized)",
+    "address": "0x400f1e257f86d25578a0928c94dc95115f09d5c9",
+    "symbol": "PGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pgon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Platinum Shares ETF (Ondo Tokenized)",
+    "address": "0x3EC23F52F6573FC0587A0631dd8C3b107f6bcb35",
+    "symbol": "PPLTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pplton_160x160.png"
+  },
+  {
+    "name": "ProShares Short QQQ (Ondo Tokenized)",
+    "address": "0x3802dc739ef9e226f36421a9c15efa519153bbbe",
+    "symbol": "PSQon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/psqon_160x160.png"
+  },
+  {
+    "name": "PayPal (Ondo Tokenized)",
+    "address": "0x374d03a6c0d5bd4be0a5117ebe1b49d52ac8a53f",
+    "symbol": "PYPLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pyplon_160x160.png"
+  },
+  {
+    "name": "Qualcomm (Ondo Tokenized)",
+    "address": "0xfbd4d681c92ead6af0e49950c8b2e47eeacbb2db",
+    "symbol": "QCOMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qcomon_160x160.png"
+  },
+  {
+    "name": "Quantum Computing (Ondo Tokenized)",
+    "address": "0x82E07C1017032cFd889b1Ca81EBe722c4D4de825",
+    "symbol": "QUBTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qubton_160x160.png"
+  },
+  {
+    "name": "Redwire (Ondo Tokenized)",
+    "address": "0x23e39D94807a8bb7e3f8294b4911D04EE26DcE39",
+    "symbol": "RDWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rdwon_160x160.png"
+  },
+  {
+    "name": "Regeneron Pharmaceuticals (Ondo Tokenized)",
+    "address": "0x30BD85fD4286c5c9857679F5B188f737B4a7B8C0",
+    "symbol": "REGNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/regnon_160x160.png"
+  },
+  {
+    "name": "Rocket Lab (Ondo Tokenized)",
+    "address": "0xb4D695569236273745B4CD54B539b1b9Cc1513af",
+    "symbol": "RKLBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rklbon_160x160.png"
+  },
+  {
+    "name": "Southern Copper (Ondo Tokenized)",
+    "address": "0xF15B8f7465b92799F6EE440F86B3CAB5A4dbc65A",
+    "symbol": "SCCOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sccoon_160x160.png"
+  },
+  {
+    "name": "Charles Schwab (Ondo Tokenized)",
+    "address": "0xe5ba472c98b7e4695bd856290de66bdedaffc123",
+    "symbol": "SCHWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/schwon_160x160.png"
+  },
+  {
+    "name": "SolarEdge Technologies (Ondo Tokenized)",
+    "address": "0x8755c5C39b1AA9053a83AC731242a2cf4D04B0Fe",
+    "symbol": "SEDGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sedgon_160x160.png"
+  },
+  {
+    "name": "iShares 1-3 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0xf95e50BE5Efc96117c28775F80C7Cdb41Ebc4888",
+    "symbol": "SHYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shyon_160x160.png"
+  },
+  {
+    "name": "SanDisk (Ondo Tokenized)",
+    "address": "0x4Fd67CB8CFEdc718BAc984b5936abE3330d0a2A4",
+    "symbol": "SNDKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sndkon_160x160.png"
+  },
+  {
+    "name": "SoundHound AI (Ondo Tokenized)",
+    "address": "0xedcf71b2e2217064038adcb54a3c3a5fc3488ef1",
+    "symbol": "SOUNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sounon_160x160.png"
+  },
+  {
+    "name": "iShares Semiconductor ETF (Ondo Tokenized)",
+    "address": "0x2A3cbF64C8181DB4a25D41D4d7a7Db9984C59DAC",
+    "symbol": "SOXXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxxon_160x160.png"
+  },
+  {
+    "name": "S&P Global (Ondo Tokenized)",
+    "address": "0x55b370b704240a914f42b5bbb3195431c031f9f8",
+    "symbol": "SPGIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spgion_160x160.png"
+  },
+  {
+    "name": "Spotify (Ondo Tokenized)",
+    "address": "0x50356167a4dbc38bea6779c045e24e25facedfdc",
+    "symbol": "SPOTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spoton_160x160.png"
+  },
+  {
+    "name": "Strategy Stretch Preferred (Ondo Tokenized)",
+    "address": "0x71E9dc9DEbc18650BD2342B93623B88C2aD00c89",
+    "symbol": "STRCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/strcon_160x160.png"
+  },
+  {
+    "name": "Seagate (Ondo Tokenized)",
+    "address": "0x966EbCBA3c51E81f5CF159a1EaBeFd2327aB5E8D",
+    "symbol": "STXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stxon_160x160.png"
+  },
+  {
+    "name": "Toyota (Ondo Tokenized)",
+    "address": "0xecc1299f183b6a720a6f4729bf24f82cd8d50828",
+    "symbol": "TMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tmon_160x160.png"
+  },
+  {
+    "name": "Texas Instruments (Ondo Tokenized)",
+    "address": "0xca3a5c955f1f01f20aacf9501b03e4aa235e478b",
+    "symbol": "TXNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/txnon_160x160.png"
+  },
+  {
+    "name": "Uranium Energy (Ondo Tokenized)",
+    "address": "0xE7ddF606841ee278A30E5C90486681e68ddd8cbF",
+    "symbol": "UECon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uecon_160x160.png"
+  },
+  {
+    "name": "US Natural Gas Fund (Ondo Tokenized)",
+    "address": "0xA5351C9bf08055E03642b6b8649A0f7e895501BF",
+    "symbol": "UNGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ungon_160x160.png"
+  },
+  {
+    "name": "Union Pacific Corporation (Ondo Tokenized)",
+    "address": "0xfe9aA194E3C4604f3872f220eb41C33A287FCD90",
+    "symbol": "UNPon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/unpon_160x160.png"
+  },
+  {
+    "name": "Global X Uranium ETF (Ondo Tokenized)",
+    "address": "0xc7806943663158D68740a14ab0B270bD60BDe87D",
+    "symbol": "URAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uraon_160x160.png"
+  },
+  {
+    "name": "WisdomTree Floating Rate Treasury Fund (Ondo Tokenized)",
+    "address": "0xf4fd75764a5c086fb12f822be2ca318b3a362dc3",
+    "symbol": "USFRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usfron_160x160.png"
+  },
+  {
+    "name": "VinFast Auto (Ondo Tokenized)",
+    "address": "0x1D2EaAF0aE00382893aa4318Bd88d1Cd0e9B858A",
+    "symbol": "VFSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vfson_160x160.png"
+  },
+  {
+    "name": "Vanguard Real Estate ETF (Ondo Tokenized)",
+    "address": "0x10b58A3d9DCeC59bB1c3bf6b9c9414eAfCE711C9",
+    "symbol": "VNQon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vnqon_160x160.png"
+  },
+  {
+    "name": "Visa (Ondo Tokenized)",
+    "address": "0x1cde419fae0ef7f7931ae3e29e5f411c8c5e5fa1",
+    "symbol": "Von",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/von_160x160.png"
+  },
+  {
+    "name": "Vertex Pharmaceuticals (Ondo Tokenized)",
+    "address": "0x8c9979Dc208f74a5602c38691aa920F121e2f863",
+    "symbol": "VRTXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrtxon_160x160.png"
+  },
+  {
+    "name": "Verizon (Ondo Tokenized)",
+    "address": "0xa3b089c886e6d721f49def8e050f3b9d4362560b",
+    "symbol": "VZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vzon_160x160.png"
+  },
+  {
+    "name": "Western Digital (Ondo Tokenized)",
+    "address": "0xcEb29848d04Ad3Cb46E1fE8E45B82ffAc39D797d",
+    "symbol": "WDCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wdcon_160x160.png"
+  },
+  {
+    "name": "Waste Management (Ondo Tokenized)",
+    "address": "0xCE0466Bae0e867239719dC386CA84b1F3eFE6914",
+    "symbol": "WMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmon_160x160.png"
+  },
+  {
+    "name": "Terawulf (Ondo Tokenized)",
+    "address": "0xad56701d9e57957e28e546db7db508a16d4f86cc",
+    "symbol": "WULFon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wulfon_160x160.png"
+  },
+  {
+    "name": "Exxon Mobil (Ondo Tokenized)",
+    "address": "0x4d209d275e3492ac08497a7a42915899c4dd5e86",
+    "symbol": "XOMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xomon_160x160.png"
+  },
+  {
+    "name": "Block (Ondo Tokenized)",
+    "address": "0xe778a2e5d953c82eb9475cf3b87654226a867344",
+    "symbol": "XYZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xyzon_160x160.png"
+  },
+  {
+    "name": "Corning (Ondo Tokenized)",
+    "address": "0x25a4DbAE9a0Cd8C75656D6b50FFDf4900CC20d8f",
+    "symbol": "GLWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/glwon_160x160.png"
+  },
+  {
+    "name": "Lumentum Holdings (Ondo Tokenized)",
+    "address": "0x0fAcaFB97ffDbA3cAe88512070AF49bd30674cD9",
+    "symbol": "LITEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/liteon_160x160.png"
+  },
+  {
+    "name": "Applied Optoelectronics (Ondo Tokenized)",
+    "address": "0x149Bda9e7251DC36f536d1fE7F92A5ea203F4F3D",
+    "symbol": "AAOIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aaoion_160x160.png"
+  },
+  {
+    "name": "AXT (Ondo Tokenized)",
+    "address": "0x0C50323AF81D5C33822c6Add256Fb9093D42BC74",
+    "symbol": "AXTIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/axtion_160x160.png"
+  },
+  {
+    "name": "nVent Electric (Ondo Tokenized)",
+    "address": "0x484Ce83BB55b50D70236C7D1E29E0Ba7524f905B",
+    "symbol": "NVTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvton_160x160.png"
+  },
+  {
+    "name": "nLIGHT (Ondo Tokenized)",
+    "address": "0x476a2caD3197Df68186b61bC36296E8d3d2d1b85",
+    "symbol": "LASRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lasron_160x160.png"
+  },
+  {
+    "name": "FormFactor (Ondo Tokenized)",
+    "address": "0xD678F3F86436Ee298d28A3C414c367aDFeD65337",
+    "symbol": "FORMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/formon_160x160.png"
+  },
+  {
+    "name": "MKS Inc. (Ondo Tokenized)",
+    "address": "0xd41699aA1BfC1c5f172c27f387372bd30717a5db",
+    "symbol": "MKSIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mksion_160x160.png"
+  },
+  {
+    "name": "Ichor Holdings (Ondo Tokenized)",
+    "address": "0xFb836dc42EBDfF6aA8DB9339336899061D1C4f3F",
+    "symbol": "ICHRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ichron_160x160.png"
+  },
+  {
+    "name": "Aehr Test Systems (Ondo Tokenized)",
+    "address": "0xdCE0957E22F7baf2AA1a50d854e03cEe6f215004",
+    "symbol": "AEHRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aehron_160x160.png"
+  },
+  {
+    "name": "Camtek (Ondo Tokenized)",
+    "address": "0xc2f65e745Fd13af1d00d5c81dD33F762FB81C264",
+    "symbol": "CAMTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/camton_160x160.png"
+  },
+  {
+    "name": "Wolfspeed (Ondo Tokenized)",
+    "address": "0x55b56CC2cdcbC2C58668F72663bE7599a46Ed79F",
+    "symbol": "WOLFon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wolfon_160x160.png"
+  },
+  {
+    "name": "Power Integrations (Ondo Tokenized)",
+    "address": "0x5417b7CFDb8a187004067297EbF1491c8D6D5C09",
+    "symbol": "POWIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/powion_160x160.png"
+  },
+  {
+    "name": "TE Connectivity (Ondo Tokenized)",
+    "address": "0x5C50fFD365c852f5e72BFBc2c1aE621e2ACa5Ece",
+    "symbol": "TELon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/telon_160x160.png"
+  },
+  {
+    "name": "Hubbell (Ondo Tokenized)",
+    "address": "0x1C42C07257F936a7c4f84B8D756c95817E23631A",
+    "symbol": "HUBBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hubbon_160x160.png"
+  },
+  {
+    "name": "Worthington Steel (Ondo Tokenized)",
+    "address": "0x50e66EDb7D0b79Ee988f098754A27aFaa643B4f5",
+    "symbol": "WSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wson_160x160.png"
+  },
+  {
+    "name": "Atkore (Ondo Tokenized)",
+    "address": "0xaFAA2087093b7B396ADAB8216506D9066c6A6F13",
+    "symbol": "ATKRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/atkron_160x160.png"
+  },
+  {
+    "name": "Cloudflare (Ondo Tokenized)",
+    "address": "0xfEb0793EEa97585Eb3a541F3FD53450D225b2B87",
+    "symbol": "NETon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/neton_160x160.png"
+  },
+  {
+    "name": "USA Rare Earth (Ondo Tokenized)",
+    "address": "0x2206E07410A8fE9Ef595e7184B2E9d160fdb7211",
+    "symbol": "USARon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usaron_160x160.png"
+  },
+  {
+    "name": "Himax Technologies (Ondo Tokenized)",
+    "address": "0x6cF3b84f0Ba4d86d9f6987812A11Db2c447D9483",
+    "symbol": "HIMXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/himxon_160x160.png"
+  },
+  {
+    "name": "MaxLinear (Ondo Tokenized)",
+    "address": "0x5Cb7671740877723c9aD55348a751D7B57052E07",
+    "symbol": "MXLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mxlon_160x160.png"
+  },
+  {
+    "name": "Onto Innovation (Ondo Tokenized)",
+    "address": "0x2F79d36184DfE7968C9d23f87cAe1aB72447c1e5",
+    "symbol": "ONTOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ontoon_160x160.png"
+  },
+  {
+    "name": "Ouster (Ondo Tokenized)",
+    "address": "0x30033A17ea24E90631532582a1917c64AFBF87Af",
+    "symbol": "OUSTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ouston_160x160.png"
+  },
+  {
+    "name": "Teradyne (Ondo Tokenized)",
+    "address": "0x6F040fC3061374304BddbfdAe9d688d7C868c785",
+    "symbol": "TERon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/teron_160x160.png"
+  },
+  {
+    "name": "Nokia (Ondo Tokenized)",
+    "address": "0xE9518CB0010C717DB69001F1418EFF9e97330137",
+    "symbol": "NOKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nokon_160x160.png"
+  },
+  {
+    "name": "Planet Labs (Ondo Tokenized)",
+    "address": "0xf9015E0b3AB4ddd216F522D6150dB826c9BE83f8",
+    "symbol": "PLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/plon_160x160.png"
+  },
+  {
+    "name": "Enbridge (Ondo Tokenized)",
+    "address": "0x5397cB3f1E419050D9d7160756dE0f4eD4f5f898",
+    "symbol": "ENBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enbon_160x160.png"
+  },
+  {
+    "name": "MYR Group (Ondo Tokenized)",
+    "address": "0x93b83111c54aa3993B2De5FCcD4c70B26c522D5d",
+    "symbol": "MYRGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/myrgon_160x160.png"
+  },
+  {
+    "name": "Entegris (Ondo Tokenized)",
+    "address": "0xfB4a89A077B9020C7101b1Af760BEB708F37a416",
+    "symbol": "ENTGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/entgon_160x160.png"
+  },
+  {
+    "name": "Hewlett Packard Enterprise (Ondo Tokenized)",
+    "address": "0x492E678c1ea048C70eDc635047cdBB87FF5362a2",
+    "symbol": "HPEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hpeon_160x160.png"
+  },
+  {
+    "name": "RoboStrategy (Ondo Tokenized)",
+    "address": "0xC43Ae29aFE58bf90dA6Fe3Edd570C2E735fb2850",
+    "symbol": "BOTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/boton_160x160.png"
+  },
+  {
+    "name": "Alpha and Omega Semiconductor (Ondo Tokenized)",
+    "address": "0x55B8cc618C4209A97250Dff926d3d708814d36aa",
+    "symbol": "AOSLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aoslon_160x160.png"
+  },
+  {
+    "name": "Bloom Energy (Ondo Tokenized)",
+    "address": "0x17D03aE104a9D12E9E5794Efb109B817Dd7f3404",
+    "symbol": "BEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/beon_160x160.png"
+  },
+  {
+    "name": "NuScale Power (Ondo Tokenized)",
+    "address": "0xf4b674D4E33c36F8db4b928A5eEC4E1F87b386e3",
+    "symbol": "SMRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/smron_160x160.png"
+  },
+  {
+    "name": "STMicroelectronics (Ondo Tokenized)",
+    "address": "0x8B46599e0E80a34F37e97DF58E741ca904cdfaBd",
+    "symbol": "STMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stmon_160x160.png"
+  },
+  {
+    "name": "EQT (Ondo Tokenized)",
+    "address": "0x9A1C88ac479906A7f03e76605b15B72DF10d8E51",
+    "symbol": "EQTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/eqton_160x160.png"
+  },
+  {
+    "name": "SAP (Ondo Tokenized)",
+    "address": "0x111f6F2B9F1C5f3Ec841690e1deEc606086727dA",
+    "symbol": "SAPon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sapon_160x160.png"
+  },
+  {
+    "name": "Williams (Ondo Tokenized)",
+    "address": "0x7B7AbD762a400c9768CDeeEF3C01DaE39e0B8427",
+    "symbol": "WMBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmbon_160x160.png"
+  },
+  {
+    "name": "NANO Nuclear Energy (Ondo Tokenized)",
+    "address": "0x3c276Dd9f9Eab5510f9eAfD3a6Ea54879b27CA3D",
+    "symbol": "NNEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nneon_160x160.png"
+  },
+  {
+    "name": "Fluence Energy (Ondo Tokenized)",
+    "address": "0xF1a96d4B591E446445600789D60C73Dd636B357c",
+    "symbol": "FLNCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flncon_160x160.png"
+  },
+  {
+    "name": "Cerebras Systems (Ondo Tokenized)",
+    "address": "0x441a4D4Fc23f17F4cf23E3d60F12d2BD6F176728",
+    "symbol": "CBRSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cbrson_160x160.png"
+  },
+  {
+    "name": "Dell Technologies (Ondo Tokenized)",
+    "address": "0xf26518958935654878De15BE7bC79A26971583Ba",
+    "symbol": "DELLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dellon_160x160.png"
+  },
+  {
+    "name": "Tower Semiconductor (Ondo Tokenized)",
+    "address": "0x343324170C91c4D8Cf4D439B3E5a619F50621aE7",
+    "symbol": "TSEMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tsemon_160x160.png"
+  },
+  {
+    "name": "Ciena (Ondo Tokenized)",
+    "address": "0x89a9F7114bE6b220fAe645ba0cbB720889867415",
+    "symbol": "CIENon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cienon_160x160.png"
+  },
+  {
+    "name": "Fabrinet (Ondo Tokenized)",
+    "address": "0xA1DaaB37dA2a29A1eC721922b55962eB8B481001",
+    "symbol": "FNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fnon_160x160.png"
+  },
+  {
+    "name": "Arqit Quantum (Ondo Tokenized)",
+    "address": "0x1161989389A991532dCE453D04d6346C2581c907",
+    "symbol": "ARQQon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/arqqon_160x160.png"
+  },
+  {
+    "name": "Astera Labs (Ondo Tokenized)",
+    "address": "0x573e11CC667A8E5BE0c7Af2410403371088D3d0D",
+    "symbol": "ALABon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/alabon_160x160.png"
+  },
+  {
+    "name": "Credo Technology Group Holding (Ondo Tokenized)",
+    "address": "0xf157481bEBd0C0686780fd0F61806C900A6137e8",
+    "symbol": "CRDOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crdoon_160x160.png"
+  },
+  {
+    "name": "MACOM Technology Solutions Holdings (Ondo Tokenized)",
+    "address": "0x1dCd320C5d7b84CD407437c58d56CbbDd0D9d8f3",
+    "symbol": "MTSIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mtsion_160x160.png"
+  },
+  {
+    "name": "Lightwave Logic (Ondo Tokenized)",
+    "address": "0x8aC67002282EeA816aFA0160d22a8d27f05BA07B",
+    "symbol": "LWLGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lwlgon_160x160.png"
+  },
+  {
+    "name": "Penguin Solutions (Ondo Tokenized)",
+    "address": "0x2144d620E3471441b12Bf256E01a09EAA5ea7F12",
+    "symbol": "PENGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pengon_160x160.png"
+  },
+  {
+    "name": "FuelCell Energy (Ondo Tokenized)",
+    "address": "0x47Bfe4921Bd74C66c6B0C35C517aBdFB5E3BAFb3",
+    "symbol": "FCELon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fcelon_160x160.png"
+  },
+  {
+    "name": "Vishay Precision Group (Ondo Tokenized)",
+    "address": "0xAd8920aFa9d158F5eBAb77c9FfcAD650D72e473D",
+    "symbol": "VPGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vpgon_160x160.png"
+  },
+  {
+    "name": "LightPath Technologies (Ondo Tokenized)",
+    "address": "0x6AD19E0A57Cfea0bC521A12C6c82372852842933",
+    "symbol": "LPTHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lpthon_160x160.png"
+  },
+  {
+    "name": "Rockwell Automation (Ondo Tokenized)",
+    "address": "0x95F7423c51Eab71cBD00ca855B0B2B2153F14184",
+    "symbol": "ROKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rokon_160x160.png"
+  },
+  {
+    "name": "Mobileye Global (Ondo Tokenized)",
+    "address": "0xCC977B493f52B4b6B6a0c3594530f2BaEe565E96",
+    "symbol": "MBLYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mblyon_160x160.png"
+  },
+  {
+    "name": "Aurora Innovation (Ondo Tokenized)",
+    "address": "0x66a1409FE303d00209202933e3d31eE43AaAB39d",
+    "symbol": "AURon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/auron_160x160.png"
+  },
+  {
+    "name": "Celestica (Ondo Tokenized)",
+    "address": "0x7b695132b165cb6703F0212bBB1e91A782526156",
+    "symbol": "CLSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/clson_160x160.png"
+  },
+  {
+    "name": "Kopin (Ondo Tokenized)",
+    "address": "0xED5615c5280E897241b9e4f019562A581cD49390",
+    "symbol": "KOPNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/kopnon_160x160.png"
+  },
+  {
+    "name": "Generac Holdings (Ondo Tokenized)",
+    "address": "0x237c9F794EDAaA0071cDF64a41c25EB76771754b",
+    "symbol": "GNRCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gnrcon_160x160.png"
+  },
+  {
+    "name": "Trane Technologies (Ondo Tokenized)",
+    "address": "0x0Afa28A7Ac4E44b1F771515c200F4d67B1f5e8d0",
+    "symbol": "TTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tton_160x160.png"
+  },
+  {
+    "name": "Fundrise Innovation Fund (Ondo Tokenized)",
+    "address": "0xC8206bB42EC019f7E7Ea060ED887E9F5bB53cBB0",
+    "symbol": "VCXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vcxon_160x160.png"
+  },
+  {
+    "name": "GlobalFoundries (Ondo Tokenized)",
+    "address": "0xAff6b836d3eBd29aEb0C8b840Add04EF79d79678",
+    "symbol": "GFSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gfson_160x160.png"
+  },
+  {
+    "name": "Energy Fuels (Ondo Tokenized)",
+    "address": "0xD2C06fef2ca2375a9C7ceB4AbcA9DBc2aB6aF981",
+    "symbol": "UUUUon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uuuuon_160x160.png"
+  },
+  {
+    "name": "Quanta Services (Ondo Tokenized)",
+    "address": "0x2418c2e1aE3B8D767594b3974D32610743f88155",
+    "symbol": "PWRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pwron_160x160.png"
+  },
+  {
+    "name": "Core Scientific (Ondo Tokenized)",
+    "address": "0x25eD86472cf3012607DC6576c58e6432968255C2",
+    "symbol": "CORZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/corzon_160x160.png"
+  },
+  {
+    "name": "Hut 8 (Ondo Tokenized)",
+    "address": "0x3A82f1C847cc55e52e597fD81c63a812C6722541",
+    "symbol": "HUTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/huton_160x160.png"
+  },
+  {
+    "name": "Vicor (Ondo Tokenized)",
+    "address": "0xa59469D91563CaeedDd2ffC731f41215E7b691ef",
+    "symbol": "VICRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vicron_160x160.png"
+  },
+  {
+    "name": "Amphenol (Ondo Tokenized)",
+    "address": "0x70AfC3a600f843d2018dF16B0b316E4BC9c603E9",
+    "symbol": "APHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aphon_160x160.png"
+  },
+  {
+    "name": "Powell Industries (Ondo Tokenized)",
+    "address": "0xD381aec27DAAcCC87F102FF4Ad6652F8b5F20bA0",
+    "symbol": "POWLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/powlon_160x160.png"
+  },
+  {
+    "name": "Cleveland-Cliffs (Ondo Tokenized)",
+    "address": "0xaC38a6608868e2f487d7993EA7339C69e5AB077b",
+    "symbol": "CLFon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/clfon_160x160.png"
+  },
+  {
+    "name": "Cameco (Ondo Tokenized)",
+    "address": "0xa75F08b9a91439DAac9cc7072857cC0a98Cf527A",
+    "symbol": "CCJon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ccjon_160x160.png"
+  },
+  {
+    "name": "Navitas Semiconductor (Ondo Tokenized)",
+    "address": "0xB56B7C2F9988448790B0F78697F405aB5e8597E6",
+    "symbol": "NVTSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvtson_160x160.png"
+  },
+  {
+    "name": "iShares Floating Rate Loan Active ETF (Ondo Tokenized)",
+    "address": "0xD41829Dec8b51119176Ee0a6b73BC8B2718546A9",
+    "symbol": "BRLNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brlnon_160x160.png"
+  },
+  {
+    "name": "iShares Investment Grade Systematic Bond ETF (Ondo Tokenized)",
+    "address": "0x9e609E96B688927aa49Dcd9758E2081f0c48ccAB",
+    "symbol": "IGEBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/igebon_160x160.png"
+  },
+  {
+    "name": "iShares Aaa - A Rated Corporate Bond ETF (Ondo Tokenized)",
+    "address": "0xBC34D36B70E5A256F3D16F9cA9D3ca3838f6cC4F",
+    "symbol": "QLTAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qltaon_160x160.png"
+  },
+  {
+    "name": "iShares High Yield Active ETF (Ondo Tokenized)",
+    "address": "0x6860a2f969A8133A23421ddce21397995139D7e8",
+    "symbol": "BRHYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brhyon_160x160.png"
+  },
+  {
+    "name": "iShares Large Cap Core Active ETF (Ondo Tokenized)",
+    "address": "0x398aE5B33505f121C359f22B300FbcFa81DB79AE",
+    "symbol": "BLCRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blcron_160x160.png"
+  },
+  {
+    "name": "iShares US Industry Rotation Active ETF (Ondo Tokenized)",
+    "address": "0x790cFb394B1f399a3543Ba1F835DdE114A387eeb",
+    "symbol": "INROon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inroon_160x160.png"
+  },
+  {
+    "name": "iShares US Equity Factor Rotation Active ETF (Ondo Tokenized)",
+    "address": "0x96A1b43C8146E6D1f6e66B226A3c520CbE3d8a50",
+    "symbol": "DYNFon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dynfon_160x160.png"
+  },
+  {
+    "name": "iShares A.I. Innovation and Tech Active ETF (Ondo Tokenized)",
+    "address": "0x2659Dd96deF34ceD3679901E5500779BE297fE5a",
+    "symbol": "BAIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/baion_160x160.png"
+  },
+  {
+    "name": "iShares International Country Rotation Active ETF (Ondo Tokenized)",
+    "address": "0x23def658ea0B4081161d9AB8fDfEef5345bcaFBD",
+    "symbol": "COROon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coroon_160x160.png"
+  },
+  {
+    "name": "iShares Total Return Active ETF (Ondo Tokenized)",
+    "address": "0x463196CC72cBad2D1AC1896CDE0766bfBBd64443",
+    "symbol": "BRTRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brtron_160x160.png"
+  },
+  {
+    "name": "iShares Systematic Alternatives Active ETF (Ondo Tokenized)",
+    "address": "0x879Fc0D8DFdb13b4aF3513d9838f82c4Df8F57E8",
+    "symbol": "IALTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ialton_160x160.png"
+  },
+  {
+    "name": "Oceaneering International (Ondo Tokenized)",
+    "address": "0x4321366277d4a6E170F1f28148C93E8c47636c14",
+    "symbol": "OIIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oiion_160x160.png"
+  },
+  {
+    "name": "Iridium Communications (Ondo Tokenized)",
+    "address": "0x3cE678692a60Fb5F31963b05CB158F0cE0Ff1736",
+    "symbol": "IRDMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/irdmon_160x160.png"
+  },
+  {
+    "name": "Leonardo DRS (Ondo Tokenized)",
+    "address": "0x2A0A317660F497d4c4836d1ef5fAF5970e69437b",
+    "symbol": "DRSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/drson_160x160.png"
+  },
+  {
+    "name": "Huntington Ingalls Industries (Ondo Tokenized)",
+    "address": "0x4Dc8dCeE22a56fEECa930dfF45581aa9A14D5E05",
+    "symbol": "HIIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hiion_160x160.png"
+  },
+  {
+    "name": "General Dynamics (Ondo Tokenized)",
+    "address": "0x5d1a9d8aa362a6424b65Fcb601e52FefcE5b4EFA",
+    "symbol": "GDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gdon_160x160.png"
+  },
+  {
+    "name": "Vanguard Energy ETF (Ondo Tokenized)",
+    "address": "0x9e23662f540C6bc117AdF91230730D9B2FDF5643",
+    "symbol": "VDEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vdeon_160x160.png"
+  },
+  {
+    "name": "Sprott Uranium Miners ETF (Ondo Tokenized)",
+    "address": "0xCa626a74420aAaf285987Da23d829f9159Ab867c",
+    "symbol": "URNMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/urnmon_160x160.png"
+  },
+  {
+    "name": "US Copper Index Fund (Ondo Tokenized)",
+    "address": "0x0888EDfeC4C0A66FCE074796CF4F6509c00f6c49",
+    "symbol": "CPERon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cperon_160x160.png"
+  },
+  {
+    "name": "First Majestic Silver (Ondo Tokenized)",
+    "address": "0xa2a97e3d6140e8ccD058f3b84230F3E1a349b1a3",
+    "symbol": "AGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/agon_160x160.png"
+  },
+  {
+    "name": "SLB (Ondo Tokenized)",
+    "address": "0xfaDdE620010736a5074a4269894Cb52B0a9a91DE",
+    "symbol": "SLBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/slbon_160x160.png"
+  },
+  {
+    "name": "Halliburton (Ondo Tokenized)",
+    "address": "0x7A18bB5FD6Ba6343180AfDCf6Dc406eF17F7fC04",
+    "symbol": "HALon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/halon_160x160.png"
+  },
+  {
+    "name": "Defiance Quantum ETF (Ondo Tokenized)",
+    "address": "0x467C7cF9AF95765C1Bd6542FfD516BF9603A19b9",
+    "symbol": "QTUMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qtumon_160x160.png"
+  },
+  {
+    "name": "Skyworks Solutions (Ondo Tokenized)",
+    "address": "0x7Bd821eAad82cb92C1eA64DaC1f3bB2E787E959A",
+    "symbol": "SWKSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/swkson_160x160.png"
+  },
+  {
+    "name": "United Microelectronics (Ondo Tokenized)",
+    "address": "0x318ddd4d03d84A40cf44772385A0CFB3D4394049",
+    "symbol": "UMCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/umcon_160x160.png"
+  },
+  {
+    "name": "Jabil (Ondo Tokenized)",
+    "address": "0x8D941EbB4921f8d43CFA65233B14A547f96559fc",
+    "symbol": "JBLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jblon_160x160.png"
+  },
+  {
+    "name": "Flex (Ondo Tokenized)",
+    "address": "0x102138be022f8D142bcB817F7264921d65209608",
+    "symbol": "FLEXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flexon_160x160.png"
+  },
+  {
+    "name": "Invesco PHLX Semiconductor ETF (Ondo Tokenized)",
+    "address": "0x15688f10470dFdDCb4E2d60CD2ACfd3eC418317a",
+    "symbol": "SOXQon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxqon_160x160.png"
+  },
+  {
+    "name": "Direxion Daily Semi Bull 3X ETF (Ondo Tokenized)",
+    "address": "0xb943c8a0d77b656Daf5244Da060D647Fd9152289",
+    "symbol": "SOXLon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxlon_160x160.png"
+  },
+  {
+    "name": "Direxion Daily Semi Bear 3X ETF (Ondo Tokenized)",
+    "address": "0x335DD4112704f108b5Ddd8F8a44Bd9ed68522a80",
+    "symbol": "SOXSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxson_160x160.png"
+  },
+  {
+    "name": "Ultra Clean Holdings (Ondo Tokenized)",
+    "address": "0xB78ccbcd9DCE42D4fa5fdC835CB6a1aa1095a3b5",
+    "symbol": "UCTTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uctton_160x160.png"
+  },
+  {
+    "name": "Axcelis Technologies (Ondo Tokenized)",
+    "address": "0xF2e14fCE9259C8A7903c4be5326058aE2D004FC7",
+    "symbol": "ACLSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aclson_160x160.png"
+  },
+  {
+    "name": "Cohu (Ondo Tokenized)",
+    "address": "0x58cE0De0CED164f2Aeab5FCf81D67f3c61CB562C",
+    "symbol": "COHUon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cohuon_160x160.png"
+  },
+  {
+    "name": "Keysight Technologies (Ondo Tokenized)",
+    "address": "0x3de956D959726C448649354C6fBCa92B82dC5Ed7",
+    "symbol": "KEYSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/keyson_160x160.png"
+  },
+  {
+    "name": "iShares Expanded Tech-Software ETF (Ondo Tokenized)",
+    "address": "0xA046C2F0A1Ac0a0E8829eFc12163ae892CEAfAc2",
+    "symbol": "IGVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/igvon_160x160.png"
+  },
+  {
+    "name": "VeriSign (Ondo Tokenized)",
+    "address": "0x37fF203Ac221313B620d047eddD7bD6F68d656a6",
+    "symbol": "VRSNon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrsnon_160x160.png"
+  },
+  {
+    "name": "Vishay Intertechnology (Ondo Tokenized)",
+    "address": "0x821aEf7d0F4347bB9EA6f293a98b19d823EEF0C5",
+    "symbol": "VSHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vshon_160x160.png"
+  },
+  {
+    "name": "Methode Electronics (Ondo Tokenized)",
+    "address": "0x89C37104aFcee9a72187E05D960a1e09763a126e",
+    "symbol": "MEIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/meion_160x160.png"
+  },
+  {
+    "name": "Rambus (Ondo Tokenized)",
+    "address": "0x49ccB157c77AFE5F264C35f0e9178a98D77815Ab",
+    "symbol": "RMBSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rmbson_160x160.png"
+  },
+  {
+    "name": "Arteris (Ondo Tokenized)",
+    "address": "0xaE922B6cc2371B6Dce592A82Fac15ef890a7D467",
+    "symbol": "AIPon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aipon_160x160.png"
+  },
+  {
+    "name": "Extreme Networks (Ondo Tokenized)",
+    "address": "0x1EadA1306DF72A5607827416c1A1307d7056dFFf",
+    "symbol": "EXTRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/extron_160x160.png"
+  },
+  {
+    "name": "WhiteFiber (Ondo Tokenized)",
+    "address": "0xCe128eDcF46B281b7df8880867B74E11B055E8E7",
+    "symbol": "WYFIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wyfion_160x160.png"
+  },
+  {
+    "name": "Digi Power X (Ondo Tokenized)",
+    "address": "0x09f5a6ee1b46787dd252827E40502c4980a0285d",
+    "symbol": "DGXXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dgxxon_160x160.png"
+  },
+  {
+    "name": "Bitdeer Technologies (Ondo Tokenized)",
+    "address": "0x3A562836AFB1026F5D7A6B6dA1125D27fdfeE372",
+    "symbol": "BTDRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btdron_160x160.png"
+  },
+  {
+    "name": "Keel Infrastructure (Ondo Tokenized)",
+    "address": "0x5e3cA19c533C8C0381eac5319624596557C279ED",
+    "symbol": "KEELon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/keelon_160x160.png"
+  },
+  {
+    "name": "HIVE Digital Technologies (Ondo Tokenized)",
+    "address": "0x3F19A16A401a6AF05150479Ccb76EF2Fb57B0dF3",
+    "symbol": "HIVEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hiveon_160x160.png"
+  },
+  {
+    "name": "TTM Technologies (Ondo Tokenized)",
+    "address": "0xF400b05AD5A791c65Acc3f905E5aDe5F1B653c8c",
+    "symbol": "TTMIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ttmion_160x160.png"
+  },
+  {
+    "name": "Primoris Services (Ondo Tokenized)",
+    "address": "0xD60b0276640a693ece55660afAC0383ca6433882",
+    "symbol": "PRIMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/primon_160x160.png"
+  },
+  {
+    "name": "Lincoln Electric (Ondo Tokenized)",
+    "address": "0x43807bf4ce06F4fbb4FA8DEac37BF274AEa324Da",
+    "symbol": "LECOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lecoon_160x160.png"
+  },
+  {
+    "name": "AMETEK (Ondo Tokenized)",
+    "address": "0x7a5bD36047A9D15C90FA79b0654De8dd9d6eBbB1",
+    "symbol": "AMEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ameon_160x160.png"
+  },
+  {
+    "name": "Forgent Power Solutions (Ondo Tokenized)",
+    "address": "0xd8dAFFd168651470cd5397A5D670DD5F8E4b02f5",
+    "symbol": "FPSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fpson_160x160.png"
+  },
+  {
+    "name": "WESCO International (Ondo Tokenized)",
+    "address": "0x82436bAE31AE373258bA567f32087eeFc32189F2",
+    "symbol": "WCCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wccon_160x160.png"
+  },
+  {
+    "name": "Breakwave Tanker Shipping ETF (Ondo Tokenized)",
+    "address": "0x472F46C5D7409C82234701EFf7D4DDA4c28B5a93",
+    "symbol": "BWETon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bweton_160x160.png"
+  },
+  {
+    "name": "Scorpio Tankers (Ondo Tokenized)",
+    "address": "0x4b1c9087a6fe265A36FBf2C591B0986fE1115F50",
+    "symbol": "STNGon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stngon_160x160.png"
+  },
+  {
+    "name": "Teekay Tankers (Ondo Tokenized)",
+    "address": "0x2BBF5ab85f9ceb595dD785Db15CC9f2931c6EA64",
+    "symbol": "TNKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tnkon_160x160.png"
+  },
+  {
+    "name": "International Seaways (Ondo Tokenized)",
+    "address": "0xE3316F5372559768E14Bc7FfE983891A742987E7",
+    "symbol": "INSWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inswon_160x160.png"
+  },
+  {
+    "name": "Tsakos Energy Navigation (Ondo Tokenized)",
+    "address": "0x686F8264625fe4E51F520Db856003A4dD52A49fF",
+    "symbol": "TENon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tenon_160x160.png"
+  },
+  {
+    "name": "Nordic American Tankers (Ondo Tokenized)",
+    "address": "0x33F3df3cEA2A8c4828e88f30Be932850cf749739",
+    "symbol": "NATon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/naton_160x160.png"
+  },
+  {
+    "name": "Okeanis Eco Tankers (Ondo Tokenized)",
+    "address": "0x660ab35bE0f102A1d4d4B60A96Ac3abfd345e038",
+    "symbol": "ECOon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ecoon_160x160.png"
+  },
+  {
+    "name": "Westlake (Ondo Tokenized)",
+    "address": "0xb3D1a5F9bF92F18da643F2Ada2f2CdfDAE67E9d1",
+    "symbol": "WLKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wlkon_160x160.png"
+  },
+  {
+    "name": "Nucor (Ondo Tokenized)",
+    "address": "0x2155f5344BA7763f80420dE617Af41E56De0552b",
+    "symbol": "NUEon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nueon_160x160.png"
+  },
+  {
+    "name": "Steel Dynamics (Ondo Tokenized)",
+    "address": "0x90EAa91Af0B4559F1F270258Bb5cDDFafbb62da9",
+    "symbol": "STLDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stldon_160x160.png"
+  },
+  {
+    "name": "Lattice Semiconductor (Ondo Tokenized)",
+    "address": "0x80F03ABCb2BD85237740dD69f87d2F5De3909012",
+    "symbol": "LSCCon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lsccon_160x160.png"
+  },
+  {
+    "name": "CEVA (Ondo Tokenized)",
+    "address": "0x8B68b3D3173c406D2C5F4f2107D54E6562A23120",
+    "symbol": "CEVAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cevaon_160x160.png"
+  },
+  {
+    "name": "Emerson Electric (Ondo Tokenized)",
+    "address": "0x60B273bDf00a9A52238Ca706257f61efc55bDeE0",
+    "symbol": "EMRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/emron_160x160.png"
+  },
+  {
+    "name": "Symbotic (Ondo Tokenized)",
+    "address": "0xc79Fc7aF952c8B41c6b7b7657dd24F44f7C10F2A",
+    "symbol": "SYMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/symon_160x160.png"
+  },
+  {
+    "name": "TaskUs (Ondo Tokenized)",
+    "address": "0xDB69bEcc323fEc440cA8eb0C3564802E77cE2827",
+    "symbol": "TASKon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/taskon_160x160.png"
+  },
+  {
+    "name": "Innodata (Ondo Tokenized)",
+    "address": "0x517A25e696421C88218B43cbb7EA0f873B6973A6",
+    "symbol": "INODon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inodon_160x160.png"
+  },
+  {
+    "name": "Hesai Group (Ondo Tokenized)",
+    "address": "0x847ef23A3F99aF79A185ce033e1664165b846eEa",
+    "symbol": "HSAIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hsaion_160x160.png"
+  },
+  {
+    "name": "United States Antimony (Ondo Tokenized)",
+    "address": "0xf8919fe7D586b11D0A900E987c4A41bC6c3195F5",
+    "symbol": "UAMYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uamyon_160x160.png"
+  },
+  {
+    "name": "REalloys (Ondo Tokenized)",
+    "address": "0x941e3a7A6fC97B094C63a0348367cf90D93Ff090",
+    "symbol": "ALOYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aloyon_160x160.png"
+  },
+  {
+    "name": "ACM Research (Ondo Tokenized)",
+    "address": "0xC5EFD0c3a8fF6D9816DA7B56625aB4C398Eb9e08",
+    "symbol": "ACMRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/acmron_160x160.png"
+  },
+  {
+    "name": "Nova (Ondo Tokenized)",
+    "address": "0x8a5f83A4b3AD2B9604F53c4dDf8DcE1329f9d433",
+    "symbol": "NVMIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvmion_160x160.png"
+  },
+  {
+    "name": "Amkor Technology (Ondo Tokenized)",
+    "address": "0xb84e150A1d18380cFeEeBCdE8756368dD489A1A3",
+    "symbol": "AMKRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amkron_160x160.png"
+  },
+  {
+    "name": "AAON (Ondo Tokenized)",
+    "address": "0x0B61036b5182A29A228d8eD9e647a16f62baD1bC",
+    "symbol": "AAONon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aaonon_160x160.png"
+  },
+  {
+    "name": "Harmonic (Ondo Tokenized)",
+    "address": "0xfF6f45B2D761CDE4dAb7F5d7A1A5f691F52F3bC3",
+    "symbol": "HLITon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hliton_160x160.png"
+  },
+  {
+    "name": "Roundhill Memory ETF (Ondo Tokenized)",
+    "address": "0x087b5761b161429013d41eA54cd2fb6022A21564",
+    "symbol": "DRAMon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dramon_160x160.png"
+  },
+  {
+    "name": "Global X MSCI Argentina ETF (Ondo Tokenized)",
+    "address": "0x2b08f1c28Cb1EdE3b11D397929F00215fA97ecFA",
+    "symbol": "ARGTon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/argton_160x160.png"
+  },
+  {
+    "name": "Hyperliquid Strategies (Ondo Tokenized)",
+    "address": "0x89CC700F308a4C59889fBF3286216554C53B0601",
+    "symbol": "PURRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/purron_160x160.png"
+  },
+  {
+    "name": "Global X Defense Tech ETF (Ondo Tokenized)",
+    "address": "0xe5ca1585c6053EE891027fD0A2548cB3B27D7f01",
+    "symbol": "SHLDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shldon_160x160.png"
+  },
+  {
+    "name": "Global X Robotics & Artificial Intelligence ETF (Ondo Tokenized)",
+    "address": "0xb42f5597EAdd424de67b46Fe5d1EC4b61367A4e5",
+    "symbol": "BOTZon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/botzon_160x160.png"
+  },
+  {
+    "name": "Global X Lithium & Battery Tech ETF (Ondo Tokenized)",
+    "address": "0xfd7778D5d4e804b5B512471Df36d60C465199A52",
+    "symbol": "LITon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/liton_160x160.png"
+  },
+  {
+    "name": "Global X Data Center & Digital Infrastructure ETF (Ondo Tokenized)",
+    "address": "0xEc4C1944682B8c7ba6c825e9A8B2B32Cb5EcacE5",
+    "symbol": "DTCRon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dtcron_160x160.png"
+  },
+  {
+    "name": "Global X Space Tech ETF (Ondo Tokenized)",
+    "address": "0x2bC97B1c5F83F080798ee9E38Da5FBF621454FCf",
+    "symbol": "ORBXon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/orbxon_160x160.png"
+  },
+  {
+    "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF (Ondo Tokenized)",
+    "address": "0x93eb8376ec73dD07F46ba7ae1EE9b0bbD937Ad93",
+    "symbol": "EUHYon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/euhyon_160x160.png"
+  },
+  {
+    "name": "iShares J.P. Morgan EM Local Currency Bond ETF (Ondo Tokenized)",
+    "address": "0x653156b9a46E21906Dddc82414871bBDB0261319",
+    "symbol": "LEMBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lembon_160x160.png"
+  },
+  {
+    "name": "iShares Defense Industrials Active ETF (Ondo Tokenized)",
+    "address": "0x5Fb339393773414039295ea97A92614fed85D556",
+    "symbol": "IDEFon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/idefon_160x160.png"
+  },
+  {
+    "name": "iShares Global Government Bond USD Hedged Active ETF (Ondo Tokenized)",
+    "address": "0x8Dd51E233E2344498F876c231a3Bd962E9750a6C",
+    "symbol": "GGOVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ggovon_160x160.png"
+  },
+  {
+    "name": "Global X NASDAQ 100 Covered Call ETF (Ondo Tokenized)",
+    "address": "0x64E023411215C3b75b9F339B7B77F179cd04C527",
+    "symbol": "QYLDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qyldon_160x160.png"
+  },
+  {
+    "name": "Global X Silver Miners ETF (Ondo Tokenized)",
+    "address": "0x6A4c1B7aA18638fac4C8e0d1961405E27C25baf1",
+    "symbol": "SILon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/silon_160x160.png"
+  },
+  {
+    "name": "Global X Artificial Intelligence & Technology ETF (Ondo Tokenized)",
+    "address": "0x333932F15E6E14f4a630163D3224548a721DdfA4",
+    "symbol": "AIQon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aiqon_160x160.png"
+  },
+  {
+    "name": "Global X Blockchain ETF (Ondo Tokenized)",
+    "address": "0x2291E5361F4ef7bB0d6703377bF497bFe4325152",
+    "symbol": "BKCHon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bkchon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI EAFE Value ETF (Ondo Tokenized)",
+    "address": "0x40375E3Dd70232eaF264706e5662b90A079e3D31",
+    "symbol": "EFVon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/efvon_160x160.png"
+  },
+  {
+    "name": "iShares S&P Small-Cap 600 Value ETF (Ondo Tokenized)",
+    "address": "0x9609f804FD90440Dd3F4AfA1E0a4D57DFd580Ce8",
+    "symbol": "IJSon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ijson_160x160.png"
+  },
+  {
+    "name": "iShares US Technology ETF (Ondo Tokenized)",
+    "address": "0xbEeEF4361F6603eDAceF5205b343C6bb6473A099",
+    "symbol": "IYWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iywon_160x160.png"
+  },
+  {
+    "name": "Global X S&P 500 Covered Call ETF (Ondo Tokenized)",
+    "address": "0x1FE12ABDF560C753aCbC63533519d74801E04958",
+    "symbol": "XYLDon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xyldon_160x160.png"
+  },
+  {
+    "name": "SPDR Bloomberg 1-3 Month T-Bill ETF (Ondo Tokenized)",
+    "address": "0x03f09E2EF6e64D804a5579E21E7b519db174cf54",
+    "symbol": "BILon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bilon_160x160.png"
+  },
+  {
+    "name": "iShares 3-7 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0x4E07B55E62f443859706E03aeA0b3fe3a1bfEA8B",
+    "symbol": "IEIon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ieion_160x160.png"
+  },
+  {
+    "name": "AB Ultra Short Income ETF (Ondo Tokenized)",
+    "address": "0x4277d20430e901092E259bA9CF7164C37077aAF1",
+    "symbol": "YEARon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/yearon_160x160.png"
+  },
+  {
+    "name": "Strive Preferred (Ondo Tokenized)",
+    "address": "0x732823512Ba98D1BCDE471ca023ee2A0C9f117b7",
+    "symbol": "SATAon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sataon_160x160.png"
+  },
+  {
+    "name": "iShares Systematic Bond ETF (Ondo Tokenized)",
+    "address": "0xeBe1408A7cce4f38dE15467e5139C3D82E4641F8",
+    "symbol": "SYSBon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sysbon_160x160.png"
+  },
+  {
+    "name": "iShares Securitized Income Active ETF (Ondo Tokenized)",
+    "address": "0xB0D7D4b65A654d43F91272Bb94E011Ce6812A2eF",
+    "symbol": "SECUon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/secuon_160x160.png"
+  },
+  {
+    "name": "iShares High Yield Corporate Bond BuyWrite Strategy ETF (Ondo Tokenized)",
+    "address": "0x85b53A9344884ae428E0E15f05A1819D280D4bE7",
+    "symbol": "HYGWon",
+    "decimals": 18,
+    "chainId": 56,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hygwon_160x160.png"
   }
 ]

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -1294,5 +1294,2405 @@
     "decimals": 18,
     "name": "Apyx Treasury USD unstaked",
     "symbol": "alqUSD"
+  },
+  {
+    "name": "Ondo U.S. Dollar Token",
+    "address": "0xAcE8E719899F6E91831B18AE746C9A965c2119F1",
+    "symbol": "USDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usdon_160x160.png"
+  },
+  {
+    "name": "American Airlines Group (Ondo Tokenized)",
+    "address": "0xbe8eb7b51a08f9d52bb6c8c7eca699f0f89bfc02",
+    "symbol": "AALon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aalon_160x160.png"
+  },
+  {
+    "name": "AbbVie (Ondo Tokenized)",
+    "address": "0x7c7378143a9c8839e0502e2178f058f46c6ea504",
+    "symbol": "ABBVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abbvon_160x160.png"
+  },
+  {
+    "name": "Archer Aviation (Ondo Tokenized)",
+    "address": "0x9cfa08002d606e638fe91941be725e1b970b84a6",
+    "symbol": "ACHRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/achron_160x160.png"
+  },
+  {
+    "name": "Analog Devices (Ondo Tokenized)",
+    "address": "0x2ddc2391cc89e3e716a938f089ae755174cfdf1f",
+    "symbol": "ADIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/adion_160x160.png"
+  },
+  {
+    "name": "Albemarle (Ondo Tokenized)",
+    "address": "0x1b468d5535Ed7C19Ce42f0073db7Fdf441028131",
+    "symbol": "ALBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/albon_160x160.png"
+  },
+  {
+    "name": "Applied Materials (Ondo Tokenized)",
+    "address": "0x6be935eadc71c49c414b1175985946ee40365c67",
+    "symbol": "AMATon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amaton_160x160.png"
+  },
+  {
+    "name": "AMC Entertainment (Ondo Tokenized)",
+    "address": "0x592643a667633bca51cb2387c98b6de6ce549a45",
+    "symbol": "AMCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amcon_160x160.png"
+  },
+  {
+    "name": "Amgen (Ondo Tokenized)",
+    "address": "0x1c5fa55eade69ae98571059332520f73733c2d82",
+    "symbol": "AMGNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amgnon_160x160.png"
+  },
+  {
+    "name": "Arista Networks (Ondo Tokenized)",
+    "address": "0x20e113e9235df6a2a9bfc6f244c2ccc380c8f546",
+    "symbol": "ANETon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aneton_160x160.png"
+  },
+  {
+    "name": "Applied Digital (Ondo Tokenized)",
+    "address": "0x318Dcb4f07C3e6ccEcc12A252100Fb3Bf76Eeb02",
+    "symbol": "APLDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/apldon_160x160.png"
+  },
+  {
+    "name": "AST SpaceMobile (Ondo Tokenized)",
+    "address": "0x0D1fa4E1E3719945899Ef7b02840627Df46aF44A",
+    "symbol": "ASTSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/astson_160x160.png"
+  },
+  {
+    "name": "Bank of America (Ondo Tokenized)",
+    "address": "0x576e9ca70e3a040c00d8139b0665a2b7b7b64844",
+    "symbol": "BACon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bacon_160x160.png"
+  },
+  {
+    "name": "BigBear.ai Holdings (Ondo Tokenized)",
+    "address": "0x1b8d3e59b31981385c066ee0916ec964628ff1f9",
+    "symbol": "BBAIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bbaion_160x160.png"
+  },
+  {
+    "name": "Bilibili (Ondo Tokenized)",
+    "address": "0x7e08ce07aca80cefe61ebbfa0cedfe5c7b07edb9",
+    "symbol": "BILIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bilion_160x160.png"
+  },
+  {
+    "name": "iShares Flexible Income Active ETF (Ondo Tokenized)",
+    "address": "0x88703c1e71f44a2d329c99e8e112f7a4e7dd6312",
+    "symbol": "BINCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bincon_160x160.png"
+  },
+  {
+    "name": "Bullish (Ondo Tokenized)",
+    "address": "0x334ccd8df4013bac99af8c5c61d3605b315302a0",
+    "symbol": "BLSHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blshon_160x160.png"
+  },
+  {
+    "name": "BitMine Immersion Technologies (Ondo Tokenized)",
+    "address": "0x33483a58079b4225b10e57958ca28ad7b9cdbaf7",
+    "symbol": "BMNRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bmnron_160x160.png"
+  },
+  {
+    "name": "US Brent Oil Fund (Ondo Tokenized)",
+    "address": "0x9ddb2524782684942FAD28b44E76552cB7f3F548",
+    "symbol": "BNOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bnoon_160x160.png"
+  },
+  {
+    "name": "B2Gold (Ondo Tokenized)",
+    "address": "0x8ac6ad49b3344024834f373f3ca491f22ceb952e",
+    "symbol": "BTGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btgon_160x160.png"
+  },
+  {
+    "name": "BitGo Holdings (Ondo Tokenized)",
+    "address": "0x510Dd21055188Eda378714DE3bb5591Ffa0CC468",
+    "symbol": "BTGOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btgoon_160x160.png"
+  },
+  {
+    "name": "Kanzhun (Ondo Tokenized)",
+    "address": "0x858e985126543b5a066c4e8a5dab0249c1d683f7",
+    "symbol": "BZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bzon_160x160.png"
+  },
+  {
+    "name": "Capricor Therapeutics (Ondo Tokenized)",
+    "address": "0x70Ec0f5B23404C0cD6f29ce88f4af00A0b0d895D",
+    "symbol": "CAPRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/capron_160x160.png"
+  },
+  {
+    "name": "First Trust NASDAQ Cybersecurity ETF (Ondo Tokenized)",
+    "address": "0x42d6E274B8631e5289a8F853E8d1A7bAEff3C8d1",
+    "symbol": "CIBRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cibron_160x160.png"
+  },
+  {
+    "name": "Cipher Mining (Ondo Tokenized)",
+    "address": "0x24e5bc45d5b6cef6f38989ac33df587a3fc850cf",
+    "symbol": "CIFRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cifron_160x160.png"
+  },
+  {
+    "name": "VanEck CLO ETF (Ondo Tokenized)",
+    "address": "0xe8b09e8175aecb35a171fa059647434fe47f114c",
+    "symbol": "CLOIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cloion_160x160.png"
+  },
+  {
+    "name": "Coherent (Ondo Tokenized)",
+    "address": "0x2B7727076B9C9B1834a2f95B81f12EEdD30db9f1",
+    "symbol": "COHRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cohron_160x160.png"
+  },
+  {
+    "name": "ConocoPhillips (Ondo Tokenized)",
+    "address": "0x8e6a5338eac4b6fe8d51a7653fad3b9da755eea6",
+    "symbol": "COPon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/copon_160x160.png"
+  },
+  {
+    "name": "Global X Copper Miners ETF (Ondo Tokenized)",
+    "address": "0x423a63dfe8d82cd9c6568c92210aa537d8ef6885",
+    "symbol": "COPXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/copxon_160x160.png"
+  },
+  {
+    "name": "Coupang (Ondo Tokenized)",
+    "address": "0xfa9f0bf8baa9a3d5e0a8e5c0aeaf186acabef63d",
+    "symbol": "CPNGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cpngon_160x160.png"
+  },
+  {
+    "name": "CrowdStrike (Ondo Tokenized)",
+    "address": "0xcac9aafb2cf51645ae1ab4fb1f35f07d42437f80",
+    "symbol": "CRWDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crwdon_160x160.png"
+  },
+  {
+    "name": "CoreWeave (Ondo Tokenized)",
+    "address": "0x66908813cd7676269494B2c6F6DBAB8B4f9E95df",
+    "symbol": "CRWVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crwvon_160x160.png"
+  },
+  {
+    "name": "Carvana (Ondo Tokenized)",
+    "address": "0xfe4ec50e0413148021d2f50d114cc44de6ffbf23",
+    "symbol": "CVNAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cvnaon_160x160.png"
+  },
+  {
+    "name": "Invesco DB Commodity Index Tracking Fund (Ondo Tokenized)",
+    "address": "0x20224080ad516769723c9a4a18325fc4e8c9ab5d",
+    "symbol": "DBCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dbcon_160x160.png"
+  },
+  {
+    "name": "Deere (Ondo Tokenized)",
+    "address": "0x32d7c413fd3477e86b8ec6b0bb8f3ac510eafaae",
+    "symbol": "DEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/deon_160x160.png"
+  },
+  {
+    "name": "WisdomTree US Quality Dividend Growth Fund (Ondo Tokenized)",
+    "address": "0x81eb954936a7062d1758fc0e6e3b88d42d9c361c",
+    "symbol": "DGRWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dgrwon_160x160.png"
+  },
+  {
+    "name": "Denison Mines (Ondo Tokenized)",
+    "address": "0x7aa59a63d1d0c435a08bc96e11bef2e95ab66c40",
+    "symbol": "DNNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dnnon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Chile ETF (Ondo Tokenized)",
+    "address": "0x74C8f41f57948Bfd8aa0D48C882d69d12d1Cc579",
+    "symbol": "ECHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/echon_160x160.png"
+  },
+  {
+    "name": "Enlivex Therapeutics (Ondo Tokenized)",
+    "address": "0xc4e6E80295154D3968519851F73f8Dc1a227286F",
+    "symbol": "ENLVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enlvon_160x160.png"
+  },
+  {
+    "name": "Enphase Energy (Ondo Tokenized)",
+    "address": "0x4F3B49aC895a29c0908c57538932967Cdc8e3c80",
+    "symbol": "ENPHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enphon_160x160.png"
+  },
+  {
+    "name": "iShares Ethereum Trust (Ondo Tokenized)",
+    "address": "0x98284FbC11eDD7540E29b896a49817Bbe52DdCBd",
+    "symbol": "ETHAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ethaon_160x160.png"
+  },
+  {
+    "name": "Eaton (Ondo Tokenized)",
+    "address": "0x9b56f5ED5A94Ae3266b7FF21953e6626F94008F1",
+    "symbol": "ETNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/etnon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Japan ETF (Ondo Tokenized)",
+    "address": "0x625Fb557cAD6D4638dae420626F3F08A485b43a8",
+    "symbol": "EWJon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewjon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI South Korea ETF (Ondo Tokenized)",
+    "address": "0xbd660e96D45e7C175512d1ed0cCc119Cb980b81a",
+    "symbol": "EWYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewyon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Brazil ETF (Ondo Tokenized)",
+    "address": "0x54021fDe36B7c4C4F9C35b02fb9A153eD8F5938A",
+    "symbol": "EWZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewzon_160x160.png"
+  },
+  {
+    "name": "Exodus Movement (Ondo Tokenized)",
+    "address": "0x185E5FA1B84F94D46ef2A33052aD39bD5f326fd8",
+    "symbol": "EXODon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/exodon_160x160.png"
+  },
+  {
+    "name": "Freeport-McMoRan (Ondo Tokenized)",
+    "address": "0xeb08d539Be0f6a6C90eA24276196E348f5688A02",
+    "symbol": "FCXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fcxon_160x160.png"
+  },
+  {
+    "name": "Franklin Focused Growth ETF (Ondo Tokenized)",
+    "address": "0x70B4082F4e3F9067dB9A2aA7520C77719E8626EE",
+    "symbol": "FFOGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ffogon_160x160.png"
+  },
+  {
+    "name": "Franklin Responsibly Sourced Gold ETF (Ondo Tokenized)",
+    "address": "0x1cB673005fc58447D881486919c14D8e7C741Bb1",
+    "symbol": "FGDLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fgdlon_160x160.png"
+  },
+  {
+    "name": "Franklin High Yield Corporate ETF (Ondo Tokenized)",
+    "address": "0x54C1Ff361b402f66c13107421E6A431C3375EF24",
+    "symbol": "FLHYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flhyon_160x160.png"
+  },
+  {
+    "name": "Franklin US Large Cap Multifactor Index ETF (Ondo Tokenized)",
+    "address": "0xC53D2e7321aB83B28aF2360559Aa303676a23f98",
+    "symbol": "FLQLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flqlon_160x160.png"
+  },
+  {
+    "name": "Fidelity Solana Fund (Ondo Tokenized)",
+    "address": "0x224B381CFAe8CCAf2e4d32D827467C2331Ce04bE",
+    "symbol": "FSOLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fsolon_160x160.png"
+  },
+  {
+    "name": "First Trust Global Tactical Commodity Strategy Fund (Ondo Tokenized)",
+    "address": "0xacf3fecaa787f268351a86409c3bd3b96ef924fb",
+    "symbol": "FTGCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ftgcon_160x160.png"
+  },
+  {
+    "name": "iShares China Large-Cap ETF (Ondo Tokenized)",
+    "address": "0x2dD57b497c777D9825A5902114BE81dF98eDE958",
+    "symbol": "FXIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fxion_160x160.png"
+  },
+  {
+    "name": "Gemini Space Station (Ondo Tokenized)",
+    "address": "0xb51db25c920c16f2865c37011c3eec91db946b07",
+    "symbol": "GEMIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gemion_160x160.png"
+  },
+  {
+    "name": "GE Vernova (Ondo Tokenized)",
+    "address": "0xA043FDc5A6E2E381e3532d5A97404b82fb7A0af8",
+    "symbol": "GEVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gevon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Precious Metals Basket Shares ETF (Ondo Tokenized)",
+    "address": "0xD0a265a32D0211a7f61F11de014B854F7ce716F8",
+    "symbol": "GLTRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gltron_160x160.png"
+  },
+  {
+    "name": "Galaxy Digital (Ondo Tokenized)",
+    "address": "0xE668e08a6f5792CEF0e63E9D98524968fDB5882f",
+    "symbol": "GLXYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/glxyon_160x160.png"
+  },
+  {
+    "name": "Grab Holdings (Ondo Tokenized)",
+    "address": "0x1c174711f3fd63c4165d6f296b3eb19d17fde94a",
+    "symbol": "GRABon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/grabon_160x160.png"
+  },
+  {
+    "name": "Home Depot (Ondo Tokenized)",
+    "address": "0x7dbd435aa4ecab5471cfcef4527a022fef0b7e1c",
+    "symbol": "HDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hdon_160x160.png"
+  },
+  {
+    "name": "PIMCO 0-5 Year High Yield Corporate Bond Index ETF (Ondo Tokenized)",
+    "address": "0xEc169F9Ac2161723a2D4febd9748BB529D6C12B5",
+    "symbol": "HYSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hyson_160x160.png"
+  },
+  {
+    "name": "iShares Bitcoin Trust (Ondo Tokenized)",
+    "address": "0x122940c4C5F9cCFAe7Fa86455a42D3EC140855cE",
+    "symbol": "IBITon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ibiton_160x160.png"
+  },
+  {
+    "name": "iShares 7-10 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0xA2eC76139028F279A1C790d323c57Cc4158098d6",
+    "symbol": "IEFon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iefon_160x160.png"
+  },
+  {
+    "name": "Franklin Income Equity Focus ETF (Ondo Tokenized)",
+    "address": "0xfA690b2B6f6b4dA518035F1d0aa8B968c23341bb",
+    "symbol": "INCEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inceon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI India ETF (Ondo Tokenized)",
+    "address": "0xa6CdB19b22B03e03EA89e133A8a46aDc3017aa6d",
+    "symbol": "INDAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/indaon_160x160.png"
+  },
+  {
+    "name": "IonQ (Ondo Tokenized)",
+    "address": "0x2F2e4b09B99fbf018F600e031aAfD9Da6347Cc75",
+    "symbol": "IONQon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ionqon_160x160.png"
+  },
+  {
+    "name": "Iren (Ondo Tokenized)",
+    "address": "0x0b59fdb1a233a7477ea14061004b9dd776e73cb3",
+    "symbol": "IRENon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/irenon_160x160.png"
+  },
+  {
+    "name": "Intuitive Surgical (Ondo Tokenized)",
+    "address": "0x2691b13fca1e02322685b9554b5ae0f5f3f05c55",
+    "symbol": "ISRGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/isrgon_160x160.png"
+  },
+  {
+    "name": "iShares US Aerospace and Defense ETF (Ondo Tokenized)",
+    "address": "0x68622855dcf14ced1B0Cc2A69cc34843708e2E0f",
+    "symbol": "ITAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/itaon_160x160.png"
+  },
+  {
+    "name": "Janus Henderson AAA CLO ETF (Ondo Tokenized)",
+    "address": "0x219a1b27baa08d72fac836665a3b752f3c9acbbc",
+    "symbol": "JAAAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jaaaon_160x160.png"
+  },
+  {
+    "name": "Johnson & Johnson (Ondo Tokenized)",
+    "address": "0xdd0e1e6162666a210905ffe8d368661b313c00e9",
+    "symbol": "JNJon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jnjon_160x160.png"
+  },
+  {
+    "name": "KLA (Ondo Tokenized)",
+    "address": "0xa637ae510cb50e61236a89ac480b93b8c3bccc46",
+    "symbol": "KLACon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/klacon_160x160.png"
+  },
+  {
+    "name": "KraneShares CSI China Internet ETF (Ondo Tokenized)",
+    "address": "0xeAA2287290544eD9F481012aa348619A4D2F9e51",
+    "symbol": "KWEBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/kwebon_160x160.png"
+  },
+  {
+    "name": "Lowe's (Ondo Tokenized)",
+    "address": "0x84328d8b85019fdcecf4c82fbe076bf350fc0cab",
+    "symbol": "LOWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lowon_160x160.png"
+  },
+  {
+    "name": "Lam Research (Ondo Tokenized)",
+    "address": "0x21be23f5bf87a749670c088f6dee26760f1ab80f",
+    "symbol": "LRCXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lrcxon_160x160.png"
+  },
+  {
+    "name": "Intuitive Machines (Ondo Tokenized)",
+    "address": "0x58a2EDF0169eDE82904e47a0E2a3a4008eDebB60",
+    "symbol": "LUNRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lunron_160x160.png"
+  },
+  {
+    "name": "Merck (Ondo Tokenized)",
+    "address": "0xdc8a7db05ea704227d56f5d4a4b77a2d1bba29c0",
+    "symbol": "MRKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrkon_160x160.png"
+  },
+  {
+    "name": "Moderna (Ondo Tokenized)",
+    "address": "0xa2c1c0b4683a871187d4565eb63abf9aef5947ee",
+    "symbol": "MRNAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrnaon_160x160.png"
+  },
+  {
+    "name": "MasTec (Ondo Tokenized)",
+    "address": "0x5cb95099a2c7e3c8187fbca6efe5ba222b5ba820",
+    "symbol": "MTZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mtzon_160x160.png"
+  },
+  {
+    "name": "Nebius Group (Ondo Tokenized)",
+    "address": "0xE4babaa960bA7D37860f3fe00D7b95D3868e8EDc",
+    "symbol": "NBISon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nbison_160x160.png"
+  },
+  {
+    "name": "NextEra Energy (Ondo Tokenized)",
+    "address": "0xf46ba88694cd7933ca28be84ee787ad5732e856b",
+    "symbol": "NEEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/neeon_160x160.png"
+  },
+  {
+    "name": "Newmont (Ondo Tokenized)",
+    "address": "0x0C802aCB21Cb2AadB2EB5E5090868E1361B26B69",
+    "symbol": "NEMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nemon_160x160.png"
+  },
+  {
+    "name": "Sprott Nickel Miners ETF (Ondo Tokenized)",
+    "address": "0xbf54eb503bb350583d11f4348086dc3608fa245c",
+    "symbol": "NIKLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/niklon_160x160.png"
+  },
+  {
+    "name": "Northrop Grumman (Ondo Tokenized)",
+    "address": "0x8Ce34F749796F82A6990fFa2d80622ef75CA7aD5",
+    "symbol": "NOCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nocon_160x160.png"
+  },
+  {
+    "name": "VanEck Oil Services ETF (Ondo Tokenized)",
+    "address": "0xBcA31049ab4782f0FfA9CfFCB2cF48e8D6dE4fb8",
+    "symbol": "OIHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oihon_160x160.png"
+  },
+  {
+    "name": "ON Semiconductor (Ondo Tokenized)",
+    "address": "0xa52b2d6ca1cd9b1e8b931645428380c340caef9a",
+    "symbol": "ONon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/onon_160x160.png"
+  },
+  {
+    "name": "Opendoor Technologies (Ondo Tokenized)",
+    "address": "0xb22d83e228c4266075ec75c32acc3bc059b6f248",
+    "symbol": "OPENon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/openon_160x160.png"
+  },
+  {
+    "name": "Opera (Ondo Tokenized)",
+    "address": "0xb40afd1d55ea61fc1a6fbe093b817b673c8e78d7",
+    "symbol": "OPRAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/opraon_160x160.png"
+  },
+  {
+    "name": "Oscar Health (Ondo Tokenized)",
+    "address": "0x244efb92f76a57da49b5f71045dce3e546e13106",
+    "symbol": "OSCRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oscron_160x160.png"
+  },
+  {
+    "name": "Occidental Petroleum (Ondo Tokenized)",
+    "address": "0xeedc48205852e9d83ea5ca92fa8656597788601f",
+    "symbol": "OXYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oxyon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Palladium Shares ETF (Ondo Tokenized)",
+    "address": "0x0ce36d199bd6851788e03392568849394cbde722",
+    "symbol": "PALLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pallon_160x160.png"
+  },
+  {
+    "name": "Global X US Infrastructure Development ETF (Ondo Tokenized)",
+    "address": "0xD4c6CCE0Cadf2fe4C0AF9eE6777989EFD8fB7670",
+    "symbol": "PAVEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/paveon_160x160.png"
+  },
+  {
+    "name": "PG&E (Ondo Tokenized)",
+    "address": "0x193fdf644451cc394b28b9cec2f5d32e2b4de515",
+    "symbol": "PCGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pcgon_160x160.png"
+  },
+  {
+    "name": "Invesco Optimum Yld Dvsfd Cmd Str No K-1 ETF (Ondo Tokenized)",
+    "address": "0x46c0a02a877c1412cb32b57028b2f771c0364a7e",
+    "symbol": "PDBCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pdbcon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Platinum Shares ETF (Ondo Tokenized)",
+    "address": "0xf1883461Ec7BD883A3668749c5CF5f351080d059",
+    "symbol": "PPLTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pplton_160x160.png"
+  },
+  {
+    "name": "ProShares Short QQQ (Ondo Tokenized)",
+    "address": "0x9ebd34d99cc3a45b39cafc14ad7994263fa2be56",
+    "symbol": "PSQon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/psqon_160x160.png"
+  },
+  {
+    "name": "Quantum Computing (Ondo Tokenized)",
+    "address": "0xc95c9e3fA311664b5e744B3C2716547BEc2Ba7dA",
+    "symbol": "QUBTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qubton_160x160.png"
+  },
+  {
+    "name": "Redwire (Ondo Tokenized)",
+    "address": "0x3a16aF9Ef328D087cc781053A2a2a27549aE6768",
+    "symbol": "RDWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rdwon_160x160.png"
+  },
+  {
+    "name": "Regeneron Pharmaceuticals (Ondo Tokenized)",
+    "address": "0x33aC34DA58168De69cE74a66fbaD81a88F974BD5",
+    "symbol": "REGNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/regnon_160x160.png"
+  },
+  {
+    "name": "Rigetti Computing (Ondo Tokenized)",
+    "address": "0xfdfdf5db2f4a72cb754ffa8896ea012dc2cc0f5e",
+    "symbol": "RGTIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rgtion_160x160.png"
+  },
+  {
+    "name": "Rocket Lab (Ondo Tokenized)",
+    "address": "0x36E3b8d9aAd0e51aC08E56a75A8f6005bF68535B",
+    "symbol": "RKLBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rklbon_160x160.png"
+  },
+  {
+    "name": "Southern Copper (Ondo Tokenized)",
+    "address": "0xdA81DA76070a7377eAEEB2978F0E13C5d57FaDb7",
+    "symbol": "SCCOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sccoon_160x160.png"
+  },
+  {
+    "name": "Charles Schwab (Ondo Tokenized)",
+    "address": "0xe737f948bdfe3beae9423292853ec0579173cebb",
+    "symbol": "SCHWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/schwon_160x160.png"
+  },
+  {
+    "name": "SolarEdge Technologies (Ondo Tokenized)",
+    "address": "0x8E82a0d7347329703FB6c6A745B1C2b3aBB1658c",
+    "symbol": "SEDGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sedgon_160x160.png"
+  },
+  {
+    "name": "iShares 0-3 Month Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0x8de5d49725550f7b318b2fa0f1b1f118e98e8d0f",
+    "symbol": "SGOVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sgovon_160x160.png"
+  },
+  {
+    "name": "iShares 1-3 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0x5C424B9b60383FCE7fE7069D2a2B1047BCd04a73",
+    "symbol": "SHYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shyon_160x160.png"
+  },
+  {
+    "name": "SanDisk (Ondo Tokenized)",
+    "address": "0x71E2400CF1Cb83204f33794eD326636A71a9AAfC",
+    "symbol": "SNDKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sndkon_160x160.png"
+  },
+  {
+    "name": "SoundHound AI (Ondo Tokenized)",
+    "address": "0x966db065199a3edea2228c6e5eb6ac49ff251acc",
+    "symbol": "SOUNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sounon_160x160.png"
+  },
+  {
+    "name": "iShares Semiconductor ETF (Ondo Tokenized)",
+    "address": "0x1fE2126bC05E4BB0468C4a198e930c889e1054a3",
+    "symbol": "SOXXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxxon_160x160.png"
+  },
+  {
+    "name": "Seagate (Ondo Tokenized)",
+    "address": "0xB53894f82a6B2d3B7365f24932B5bDE1c5Fb51FF",
+    "symbol": "STXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stxon_160x160.png"
+  },
+  {
+    "name": "AT&T (Ondo Tokenized)",
+    "address": "0x3361a73262199873b74d6835760a59b8817fa592",
+    "symbol": "Ton",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ton_160x160.png"
+  },
+  {
+    "name": "Texas Instruments (Ondo Tokenized)",
+    "address": "0x58fc9d573ea773ef9a25c3de66f990b87ee5f50e",
+    "symbol": "TXNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/txnon_160x160.png"
+  },
+  {
+    "name": "Uranium Energy (Ondo Tokenized)",
+    "address": "0x0F8887772262c449793890DCD3Bf320308dB423B",
+    "symbol": "UECon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uecon_160x160.png"
+  },
+  {
+    "name": "US Natural Gas Fund (Ondo Tokenized)",
+    "address": "0x7C488cFc874Ca9F34e7bdBd0410C27CE6d6af5f9",
+    "symbol": "UNGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ungon_160x160.png"
+  },
+  {
+    "name": "Union Pacific Corporation (Ondo Tokenized)",
+    "address": "0x39930751d4569F7DD45d1bA46E82CD3680EC2e0a",
+    "symbol": "UNPon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/unpon_160x160.png"
+  },
+  {
+    "name": "Global X Uranium ETF (Ondo Tokenized)",
+    "address": "0xf98Ec282300892b3518B5cB996012b18d9B7D435",
+    "symbol": "URAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uraon_160x160.png"
+  },
+  {
+    "name": "WisdomTree Floating Rate Treasury Fund (Ondo Tokenized)",
+    "address": "0xfb82561a955bf59b9263301126af490d3799e231",
+    "symbol": "USFRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usfron_160x160.png"
+  },
+  {
+    "name": "United States Oil Fund (Ondo Tokenized)",
+    "address": "0x1f5fc5c3c8b0f15c7e21af623936ff2b210b6415",
+    "symbol": "USOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usoon_160x160.png"
+  },
+  {
+    "name": "VinFast Auto (Ondo Tokenized)",
+    "address": "0xBFe6e76A2FE099392064fbB3E868558C82bEb917",
+    "symbol": "VFSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vfson_160x160.png"
+  },
+  {
+    "name": "Vanguard Real Estate ETF (Ondo Tokenized)",
+    "address": "0xcCAe8843E26259278C200C6506F6E5A3bdD524cd",
+    "symbol": "VNQon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vnqon_160x160.png"
+  },
+  {
+    "name": "Vertex Pharmaceuticals (Ondo Tokenized)",
+    "address": "0xFC003a764a7B5054Cc6fDb6b511F35deC8022751",
+    "symbol": "VRTXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrtxon_160x160.png"
+  },
+  {
+    "name": "Verizon (Ondo Tokenized)",
+    "address": "0x0e3d889d5b857c3e6eb361b9c9ae35bb7ddbd254",
+    "symbol": "VZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vzon_160x160.png"
+  },
+  {
+    "name": "Western Digital (Ondo Tokenized)",
+    "address": "0x44e89d34601b8D0155e16634d2553EF7F54DBab2",
+    "symbol": "WDCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wdcon_160x160.png"
+  },
+  {
+    "name": "Waste Management (Ondo Tokenized)",
+    "address": "0x1fb5a8DCd70bE750a97Eaf8a47bBe74Ab7d3183e",
+    "symbol": "WMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmon_160x160.png"
+  },
+  {
+    "name": "Terawulf (Ondo Tokenized)",
+    "address": "0x110cae53912c2ed9bf279cd70b3b699e26c79e58",
+    "symbol": "WULFon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wulfon_160x160.png"
+  },
+  {
+    "name": "Exxon Mobil (Ondo Tokenized)",
+    "address": "0xf05ad9840924ea6f977ebccb3b1da87e31dcd0b4",
+    "symbol": "XOMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xomon_160x160.png"
+  },
+  {
+    "name": "Block (Ondo Tokenized)",
+    "address": "0x6cc41275ef02b4eeccc04fc4424849a96f3272aa",
+    "symbol": "XYZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xyzon_160x160.png"
+  },
+  {
+    "name": "Corning (Ondo Tokenized)",
+    "address": "0xE45575b8895664DEdf7bEfFEe98b078F2Cf1A192",
+    "symbol": "GLWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/glwon_160x160.png"
+  },
+  {
+    "name": "Lumentum Holdings (Ondo Tokenized)",
+    "address": "0xbF5ab848efff75D897a3DBE4647B939C59D3cdb0",
+    "symbol": "LITEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/liteon_160x160.png"
+  },
+  {
+    "name": "Applied Optoelectronics (Ondo Tokenized)",
+    "address": "0x99888f2CCD08258eD5F66e94bA59d7E75016900F",
+    "symbol": "AAOIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aaoion_160x160.png"
+  },
+  {
+    "name": "AXT (Ondo Tokenized)",
+    "address": "0x6a3E77d984e22bed6A036D3DA79D7857936a593f",
+    "symbol": "AXTIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/axtion_160x160.png"
+  },
+  {
+    "name": "nVent Electric (Ondo Tokenized)",
+    "address": "0x38cBBBF83Ab583E231960B5c112145324Bef55ae",
+    "symbol": "NVTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvton_160x160.png"
+  },
+  {
+    "name": "nLIGHT (Ondo Tokenized)",
+    "address": "0x62D5854E309E7F7fC27ff6EbEfb54D2b235A0E9B",
+    "symbol": "LASRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lasron_160x160.png"
+  },
+  {
+    "name": "FormFactor (Ondo Tokenized)",
+    "address": "0x6401365aA495ca96Bcfcf9c6c47Bd4a590336b00",
+    "symbol": "FORMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/formon_160x160.png"
+  },
+  {
+    "name": "MKS Inc. (Ondo Tokenized)",
+    "address": "0xDc4F9c9CAa96046816255Bc6c10fd6433863128E",
+    "symbol": "MKSIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mksion_160x160.png"
+  },
+  {
+    "name": "Ichor Holdings (Ondo Tokenized)",
+    "address": "0xdFCa97fB2A3163011f3b5B3198F63D9Ab8F04A98",
+    "symbol": "ICHRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ichron_160x160.png"
+  },
+  {
+    "name": "Aehr Test Systems (Ondo Tokenized)",
+    "address": "0xeB48e68F01c0C76735dc6F1dcC0F151A973BD9d2",
+    "symbol": "AEHRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aehron_160x160.png"
+  },
+  {
+    "name": "Camtek (Ondo Tokenized)",
+    "address": "0xC087EA645a1eFE021577c19413FBE39d617A3196",
+    "symbol": "CAMTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/camton_160x160.png"
+  },
+  {
+    "name": "Wolfspeed (Ondo Tokenized)",
+    "address": "0x995584539633F7d28757B6329A42439BD8aeCEde",
+    "symbol": "WOLFon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wolfon_160x160.png"
+  },
+  {
+    "name": "Power Integrations (Ondo Tokenized)",
+    "address": "0xE172Fb6B867F873Db7Cb2D7435B95a07e5deFE81",
+    "symbol": "POWIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/powion_160x160.png"
+  },
+  {
+    "name": "TE Connectivity (Ondo Tokenized)",
+    "address": "0x7C17a5423200246EAFdd9fa0f5d70eAde3067Dd6",
+    "symbol": "TELon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/telon_160x160.png"
+  },
+  {
+    "name": "Hubbell (Ondo Tokenized)",
+    "address": "0x24e7504246DFdd7E866936e2816BFbEa73bd890a",
+    "symbol": "HUBBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hubbon_160x160.png"
+  },
+  {
+    "name": "Worthington Steel (Ondo Tokenized)",
+    "address": "0x7F24e4f5dc9ce7D00170C91Ce18326E01d702242",
+    "symbol": "WSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wson_160x160.png"
+  },
+  {
+    "name": "Atkore (Ondo Tokenized)",
+    "address": "0xB50A8bd8883Dfe59eAF1a8b1130acD97CEd9AC84",
+    "symbol": "ATKRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/atkron_160x160.png"
+  },
+  {
+    "name": "Cloudflare (Ondo Tokenized)",
+    "address": "0x4f5A3B3E184b1424816D9107448314ba0aAd63e1",
+    "symbol": "NETon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/neton_160x160.png"
+  },
+  {
+    "name": "USA Rare Earth (Ondo Tokenized)",
+    "address": "0xE2c149FA719d43912BfE584c71c9a6a018a5e916",
+    "symbol": "USARon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usaron_160x160.png"
+  },
+  {
+    "name": "Himax Technologies (Ondo Tokenized)",
+    "address": "0xabC32C14CE8502Ff6B63Adc2907B9458c06A6856",
+    "symbol": "HIMXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/himxon_160x160.png"
+  },
+  {
+    "name": "MaxLinear (Ondo Tokenized)",
+    "address": "0xD1C3bF5DdE6ee17Ae2a472a8C4f0258e0B350cb4",
+    "symbol": "MXLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mxlon_160x160.png"
+  },
+  {
+    "name": "Onto Innovation (Ondo Tokenized)",
+    "address": "0xC29FF16a7B0a895E9fE05c32Ce3f26c44e8eca3D",
+    "symbol": "ONTOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ontoon_160x160.png"
+  },
+  {
+    "name": "Ouster (Ondo Tokenized)",
+    "address": "0x67A47353D5449fC24088190c44247d4D4E296073",
+    "symbol": "OUSTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ouston_160x160.png"
+  },
+  {
+    "name": "Teradyne (Ondo Tokenized)",
+    "address": "0x1d1b9ae25722d0B27dB23171CFeE0C269B203695",
+    "symbol": "TERon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/teron_160x160.png"
+  },
+  {
+    "name": "Nokia (Ondo Tokenized)",
+    "address": "0x01E7eaF05Be1d0c2D1834fC65080188376026d07",
+    "symbol": "NOKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nokon_160x160.png"
+  },
+  {
+    "name": "Planet Labs (Ondo Tokenized)",
+    "address": "0xa656C5Dd6B64b3AcB6E32aF8A876a48B5748f858",
+    "symbol": "PLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/plon_160x160.png"
+  },
+  {
+    "name": "Enbridge (Ondo Tokenized)",
+    "address": "0xB2e9Ec5c62f78596cA4a21a21570b9a00c6D226c",
+    "symbol": "ENBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enbon_160x160.png"
+  },
+  {
+    "name": "MYR Group (Ondo Tokenized)",
+    "address": "0x1DB23e5C0da6b960D0cf3D9939Cbf50A2514bfC2",
+    "symbol": "MYRGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/myrgon_160x160.png"
+  },
+  {
+    "name": "Entegris (Ondo Tokenized)",
+    "address": "0x44Abf03ca01B8e7877bC3Dbc37b132F6f25E9450",
+    "symbol": "ENTGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/entgon_160x160.png"
+  },
+  {
+    "name": "Hewlett Packard Enterprise (Ondo Tokenized)",
+    "address": "0xE67AbcA57E1504a26bd2eD209F2e0C09543Fd7Eb",
+    "symbol": "HPEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hpeon_160x160.png"
+  },
+  {
+    "name": "RoboStrategy (Ondo Tokenized)",
+    "address": "0x0e05BA0756C504B69AAA642f7379CD1AF7C63969",
+    "symbol": "BOTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/boton_160x160.png"
+  },
+  {
+    "name": "Alpha and Omega Semiconductor (Ondo Tokenized)",
+    "address": "0x55025c1e2acFE5A7092CF32f7A4F351a9FD21e1c",
+    "symbol": "AOSLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aoslon_160x160.png"
+  },
+  {
+    "name": "Bloom Energy (Ondo Tokenized)",
+    "address": "0x92e04b1fCC2b16347820241D226853Cf01C9eBAB",
+    "symbol": "BEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/beon_160x160.png"
+  },
+  {
+    "name": "NuScale Power (Ondo Tokenized)",
+    "address": "0x0a600856eEDCe367eD49C3cd399775DC95d8BB5a",
+    "symbol": "SMRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/smron_160x160.png"
+  },
+  {
+    "name": "STMicroelectronics (Ondo Tokenized)",
+    "address": "0xF5852886Fff060dF3Af99a4246456fCa26445e8c",
+    "symbol": "STMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stmon_160x160.png"
+  },
+  {
+    "name": "EQT (Ondo Tokenized)",
+    "address": "0x05d2d23398756821dC3DE359ffCe8EBbD50af8c5",
+    "symbol": "EQTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/eqton_160x160.png"
+  },
+  {
+    "name": "SAP (Ondo Tokenized)",
+    "address": "0xCAfD1c0EE8B392cb446e3E745A4ADEfF7A861995",
+    "symbol": "SAPon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sapon_160x160.png"
+  },
+  {
+    "name": "Williams (Ondo Tokenized)",
+    "address": "0xfB6d594CccfDEd3606e1500b92a26b8B43a35071",
+    "symbol": "WMBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmbon_160x160.png"
+  },
+  {
+    "name": "NANO Nuclear Energy (Ondo Tokenized)",
+    "address": "0xb5dd7ff8E2e4019cA7a55f10C13282071a5775D4",
+    "symbol": "NNEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nneon_160x160.png"
+  },
+  {
+    "name": "Fluence Energy (Ondo Tokenized)",
+    "address": "0xf6C9C6b33BD3df0d761702db7075f89e561A54D8",
+    "symbol": "FLNCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flncon_160x160.png"
+  },
+  {
+    "name": "Cerebras Systems (Ondo Tokenized)",
+    "address": "0x61882Bb63aF8e6A39531175CdfDe1Fcd98346503",
+    "symbol": "CBRSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cbrson_160x160.png"
+  },
+  {
+    "name": "Dell Technologies (Ondo Tokenized)",
+    "address": "0xeE9f43476C5b7292b114bA1b280A42A8746792d4",
+    "symbol": "DELLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dellon_160x160.png"
+  },
+  {
+    "name": "Tower Semiconductor (Ondo Tokenized)",
+    "address": "0xEbe0D1B1d50bC68458Fcdc45C3c276d57CDC422B",
+    "symbol": "TSEMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tsemon_160x160.png"
+  },
+  {
+    "name": "Ciena (Ondo Tokenized)",
+    "address": "0x1ffAc2Df9696868D06F9fe8d72fEE9e1452eeF76",
+    "symbol": "CIENon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cienon_160x160.png"
+  },
+  {
+    "name": "Fabrinet (Ondo Tokenized)",
+    "address": "0x93A96721a624822A6aB6461A7891a5C6b154102F",
+    "symbol": "FNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fnon_160x160.png"
+  },
+  {
+    "name": "Arqit Quantum (Ondo Tokenized)",
+    "address": "0x45583545BE579cc96409903597c5e17B3fd7ceFf",
+    "symbol": "ARQQon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/arqqon_160x160.png"
+  },
+  {
+    "name": "Astera Labs (Ondo Tokenized)",
+    "address": "0xd6D09189B6fD611A75435e4a123e373A56Ab0e41",
+    "symbol": "ALABon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/alabon_160x160.png"
+  },
+  {
+    "name": "Credo Technology Group Holding (Ondo Tokenized)",
+    "address": "0xB348a4Bce7FaE890d2d37Ea104e59fb3881757c2",
+    "symbol": "CRDOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crdoon_160x160.png"
+  },
+  {
+    "name": "MACOM Technology Solutions Holdings (Ondo Tokenized)",
+    "address": "0x6e9C4BcEDDd057D66b65794A0093ad95c5fa0Cc4",
+    "symbol": "MTSIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mtsion_160x160.png"
+  },
+  {
+    "name": "Lightwave Logic (Ondo Tokenized)",
+    "address": "0x5bC56F5A324BB572B934cED4448055e30ec11c0c",
+    "symbol": "LWLGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lwlgon_160x160.png"
+  },
+  {
+    "name": "Penguin Solutions (Ondo Tokenized)",
+    "address": "0x41fA6d32917E17cF29a5e93940471492D7c301C8",
+    "symbol": "PENGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pengon_160x160.png"
+  },
+  {
+    "name": "FuelCell Energy (Ondo Tokenized)",
+    "address": "0xb71c4EBB4eDbAd867290206239C19DBb59eD55E1",
+    "symbol": "FCELon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fcelon_160x160.png"
+  },
+  {
+    "name": "Vishay Precision Group (Ondo Tokenized)",
+    "address": "0x1c4c8a66884F1eeC60AA203C6cB51fD6CB76dbb9",
+    "symbol": "VPGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vpgon_160x160.png"
+  },
+  {
+    "name": "LightPath Technologies (Ondo Tokenized)",
+    "address": "0x9A73A9CC7c5889C521423870e896904F71562504",
+    "symbol": "LPTHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lpthon_160x160.png"
+  },
+  {
+    "name": "Rockwell Automation (Ondo Tokenized)",
+    "address": "0x4ef7A9145e7B3C92E23A97FB41A9F4E9856288CB",
+    "symbol": "ROKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rokon_160x160.png"
+  },
+  {
+    "name": "Mobileye Global (Ondo Tokenized)",
+    "address": "0xc4Fa11Ed5141195cCBa19180628fa5091f53790b",
+    "symbol": "MBLYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mblyon_160x160.png"
+  },
+  {
+    "name": "Aurora Innovation (Ondo Tokenized)",
+    "address": "0xFc9D0eBBd17d3aAa336a50488795806c69EA4b32",
+    "symbol": "AURon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/auron_160x160.png"
+  },
+  {
+    "name": "Celestica (Ondo Tokenized)",
+    "address": "0x1630281079eBaC2E873FB1F1cB41df3D0e451E23",
+    "symbol": "CLSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/clson_160x160.png"
+  },
+  {
+    "name": "Kopin (Ondo Tokenized)",
+    "address": "0xD569Ff7f1560F71874Bc52D4728Fb2921e3DcE05",
+    "symbol": "KOPNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/kopnon_160x160.png"
+  },
+  {
+    "name": "Generac Holdings (Ondo Tokenized)",
+    "address": "0xD120f60FeC8189ed4a2346E10107B0F1F61354Cb",
+    "symbol": "GNRCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gnrcon_160x160.png"
+  },
+  {
+    "name": "Trane Technologies (Ondo Tokenized)",
+    "address": "0x26E78f7170d8Cc3bd3865d37CE4c554B65B1C9ba",
+    "symbol": "TTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tton_160x160.png"
+  },
+  {
+    "name": "Fundrise Innovation Fund (Ondo Tokenized)",
+    "address": "0x8B935EB2c98B597577359dEF9B18b4ae1523E6Cf",
+    "symbol": "VCXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vcxon_160x160.png"
+  },
+  {
+    "name": "GlobalFoundries (Ondo Tokenized)",
+    "address": "0xB326821B68313082F00A1A4d6Fa3f924D3E826Dc",
+    "symbol": "GFSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gfson_160x160.png"
+  },
+  {
+    "name": "Energy Fuels (Ondo Tokenized)",
+    "address": "0xF14d47AeD45e16BF1f6E06904ac7f852FCe6cdf4",
+    "symbol": "UUUUon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uuuuon_160x160.png"
+  },
+  {
+    "name": "Quanta Services (Ondo Tokenized)",
+    "address": "0xB4d71137656150E97f3ed2C18d4a30bE138D8f2e",
+    "symbol": "PWRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pwron_160x160.png"
+  },
+  {
+    "name": "Core Scientific (Ondo Tokenized)",
+    "address": "0xddAf7945093ad7457228c185783FDf6aB25022B2",
+    "symbol": "CORZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/corzon_160x160.png"
+  },
+  {
+    "name": "Hut 8 (Ondo Tokenized)",
+    "address": "0xdf3F2315D124F7F8b714Ba031d6e69aA16a61FA2",
+    "symbol": "HUTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/huton_160x160.png"
+  },
+  {
+    "name": "Vicor (Ondo Tokenized)",
+    "address": "0x6c51001149c7782820c107ADcE650692aB6c5378",
+    "symbol": "VICRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vicron_160x160.png"
+  },
+  {
+    "name": "Amphenol (Ondo Tokenized)",
+    "address": "0xD9C1b5df94063177CF168680b695A417919aE1ae",
+    "symbol": "APHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aphon_160x160.png"
+  },
+  {
+    "name": "Powell Industries (Ondo Tokenized)",
+    "address": "0x1b8085e78877dfBA98692Cb918809b35f6280015",
+    "symbol": "POWLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/powlon_160x160.png"
+  },
+  {
+    "name": "Cleveland-Cliffs (Ondo Tokenized)",
+    "address": "0xa95837130Bcbc0AD99e188E22F674E4eC6925be2",
+    "symbol": "CLFon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/clfon_160x160.png"
+  },
+  {
+    "name": "Cameco (Ondo Tokenized)",
+    "address": "0xA9F9BE37b19F261AB067C5f7DEDA2c969Ec66944",
+    "symbol": "CCJon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ccjon_160x160.png"
+  },
+  {
+    "name": "Navitas Semiconductor (Ondo Tokenized)",
+    "address": "0x2D9fc6C5dD136658ab6190f356ae3186c4Daa7D5",
+    "symbol": "NVTSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvtson_160x160.png"
+  },
+  {
+    "name": "iShares Floating Rate Loan Active ETF (Ondo Tokenized)",
+    "address": "0xfcBa0eEBbb946FF933C91D2DDB2991845a400F39",
+    "symbol": "BRLNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brlnon_160x160.png"
+  },
+  {
+    "name": "iShares Investment Grade Systematic Bond ETF (Ondo Tokenized)",
+    "address": "0x65513b741541025731124408DEb1A714699E3ee8",
+    "symbol": "IGEBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/igebon_160x160.png"
+  },
+  {
+    "name": "iShares Aaa - A Rated Corporate Bond ETF (Ondo Tokenized)",
+    "address": "0xD175B950B71f623BcD31c430C23e3e4a3487BDa3",
+    "symbol": "QLTAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qltaon_160x160.png"
+  },
+  {
+    "name": "iShares High Yield Active ETF (Ondo Tokenized)",
+    "address": "0xaeB2C4f3540a162045cC3Bd82d367AC38C2F4Da6",
+    "symbol": "BRHYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brhyon_160x160.png"
+  },
+  {
+    "name": "iShares Large Cap Core Active ETF (Ondo Tokenized)",
+    "address": "0x08D777b6a82c8dee715848702F72dAD4c2504687",
+    "symbol": "BLCRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blcron_160x160.png"
+  },
+  {
+    "name": "iShares US Industry Rotation Active ETF (Ondo Tokenized)",
+    "address": "0xcafC59d86FAD601ea321c44439fE9D5B8F02ef0F",
+    "symbol": "INROon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inroon_160x160.png"
+  },
+  {
+    "name": "iShares US Equity Factor Rotation Active ETF (Ondo Tokenized)",
+    "address": "0xa32847395b007ee4a40407E3DD2f8F9bF56Ca6aB",
+    "symbol": "DYNFon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dynfon_160x160.png"
+  },
+  {
+    "name": "iShares A.I. Innovation and Tech Active ETF (Ondo Tokenized)",
+    "address": "0x9463b0EE32c1b40B7fdA6459e815F0790159bC3A",
+    "symbol": "BAIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/baion_160x160.png"
+  },
+  {
+    "name": "iShares International Country Rotation Active ETF (Ondo Tokenized)",
+    "address": "0x744f87836d961E08b9305c690d663577718a0d0A",
+    "symbol": "COROon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coroon_160x160.png"
+  },
+  {
+    "name": "iShares Total Return Active ETF (Ondo Tokenized)",
+    "address": "0x3d45D340a30f49F036142e5e4D8993b9ad4e3F9a",
+    "symbol": "BRTRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brtron_160x160.png"
+  },
+  {
+    "name": "iShares Systematic Alternatives Active ETF (Ondo Tokenized)",
+    "address": "0x9ED446b5CC93803291BfDa5346a5b634a93A500C",
+    "symbol": "IALTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ialton_160x160.png"
+  },
+  {
+    "name": "Oceaneering International (Ondo Tokenized)",
+    "address": "0x5673154DAe5Dab8ca6Bd3ee42c3245dbFedC6611",
+    "symbol": "OIIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oiion_160x160.png"
+  },
+  {
+    "name": "Iridium Communications (Ondo Tokenized)",
+    "address": "0xd0E60D2EF0841E49700772D9889123b9886194c7",
+    "symbol": "IRDMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/irdmon_160x160.png"
+  },
+  {
+    "name": "Leonardo DRS (Ondo Tokenized)",
+    "address": "0x448550De96bCBEF1d8ccd755b5BC842f58485b46",
+    "symbol": "DRSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/drson_160x160.png"
+  },
+  {
+    "name": "Huntington Ingalls Industries (Ondo Tokenized)",
+    "address": "0x10bd54f1F4DC19bE0c46B1Ea7E5f38FD2eaFeE26",
+    "symbol": "HIIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hiion_160x160.png"
+  },
+  {
+    "name": "General Dynamics (Ondo Tokenized)",
+    "address": "0xD68fa0978C257aace5BEc5246b201B56E838D45d",
+    "symbol": "GDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gdon_160x160.png"
+  },
+  {
+    "name": "Vanguard Energy ETF (Ondo Tokenized)",
+    "address": "0x241Aa03de25Bd3A6B6254258BEF7F287AF94b93C",
+    "symbol": "VDEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vdeon_160x160.png"
+  },
+  {
+    "name": "Sprott Uranium Miners ETF (Ondo Tokenized)",
+    "address": "0xa65db7879774BD6758ABaF583A91177AfD96D5A3",
+    "symbol": "URNMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/urnmon_160x160.png"
+  },
+  {
+    "name": "US Copper Index Fund (Ondo Tokenized)",
+    "address": "0x22a684E0A3cc9B74596719F722cf4e597AAFA3bA",
+    "symbol": "CPERon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cperon_160x160.png"
+  },
+  {
+    "name": "First Majestic Silver (Ondo Tokenized)",
+    "address": "0xaa26e62e51bc5da24ED2B6Fc6491e137d68824B9",
+    "symbol": "AGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/agon_160x160.png"
+  },
+  {
+    "name": "SLB (Ondo Tokenized)",
+    "address": "0xCEA4290d6578f0253308304F7184eA2E8F5EB0E4",
+    "symbol": "SLBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/slbon_160x160.png"
+  },
+  {
+    "name": "Halliburton (Ondo Tokenized)",
+    "address": "0x596b790CceE1032F6658Ac2c78a119cCE69727FC",
+    "symbol": "HALon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/halon_160x160.png"
+  },
+  {
+    "name": "Defiance Quantum ETF (Ondo Tokenized)",
+    "address": "0x4c26BeBd3EC5B0329f24dfeD0de10a7AD205D8c3",
+    "symbol": "QTUMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qtumon_160x160.png"
+  },
+  {
+    "name": "Skyworks Solutions (Ondo Tokenized)",
+    "address": "0xC15F11599828b0afB0C071994679EF9E685F9E2E",
+    "symbol": "SWKSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/swkson_160x160.png"
+  },
+  {
+    "name": "United Microelectronics (Ondo Tokenized)",
+    "address": "0x9784508a0758cBb43eCb9b62F4CF4b1b3a36480c",
+    "symbol": "UMCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/umcon_160x160.png"
+  },
+  {
+    "name": "Jabil (Ondo Tokenized)",
+    "address": "0xD9584f80CCE13afC96BfD0188fd5C81E08f18C85",
+    "symbol": "JBLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jblon_160x160.png"
+  },
+  {
+    "name": "Flex (Ondo Tokenized)",
+    "address": "0x4493E670F5a077D46Eb3389fFA9Af19999Ea54eD",
+    "symbol": "FLEXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flexon_160x160.png"
+  },
+  {
+    "name": "Invesco PHLX Semiconductor ETF (Ondo Tokenized)",
+    "address": "0x4032d3076974b89238adfe61085EC57fC4522646",
+    "symbol": "SOXQon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxqon_160x160.png"
+  },
+  {
+    "name": "Direxion Daily Semi Bull 3X ETF (Ondo Tokenized)",
+    "address": "0xd318bBBE6B6E83F74e7aCAEb5e94C08ddbDb44c0",
+    "symbol": "SOXLon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxlon_160x160.png"
+  },
+  {
+    "name": "Direxion Daily Semi Bear 3X ETF (Ondo Tokenized)",
+    "address": "0x01eb2eE6Ec05C304666210133B762088FF9965aC",
+    "symbol": "SOXSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxson_160x160.png"
+  },
+  {
+    "name": "Ultra Clean Holdings (Ondo Tokenized)",
+    "address": "0x77ADB9F3ff7aAcBA0eEcE50d1bBf51adA182d174",
+    "symbol": "UCTTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uctton_160x160.png"
+  },
+  {
+    "name": "Axcelis Technologies (Ondo Tokenized)",
+    "address": "0x6785cE8060655b1F4991C3893dc41814154A1808",
+    "symbol": "ACLSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aclson_160x160.png"
+  },
+  {
+    "name": "Cohu (Ondo Tokenized)",
+    "address": "0x948B03e4A1F1330d86Ea3adE02482639B5cCe720",
+    "symbol": "COHUon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cohuon_160x160.png"
+  },
+  {
+    "name": "Keysight Technologies (Ondo Tokenized)",
+    "address": "0x1E328BBCd67e1bbEE198bb3F90e764812e6E0AC9",
+    "symbol": "KEYSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/keyson_160x160.png"
+  },
+  {
+    "name": "iShares Expanded Tech-Software ETF (Ondo Tokenized)",
+    "address": "0xa9E5c59f34397fe6Baa9E4dA139bA4E63Bd84324",
+    "symbol": "IGVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/igvon_160x160.png"
+  },
+  {
+    "name": "VeriSign (Ondo Tokenized)",
+    "address": "0xc5a72B01Cc9e2721DC6dE1A35Ab8d92A6AA273e6",
+    "symbol": "VRSNon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrsnon_160x160.png"
+  },
+  {
+    "name": "Vishay Intertechnology (Ondo Tokenized)",
+    "address": "0x6987F17A188c3B64F4892f0E31C2ccd88F54FCFd",
+    "symbol": "VSHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vshon_160x160.png"
+  },
+  {
+    "name": "Methode Electronics (Ondo Tokenized)",
+    "address": "0x84601fdB21e3e892104e1Fe4a8269E7acA7C0E1A",
+    "symbol": "MEIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/meion_160x160.png"
+  },
+  {
+    "name": "Rambus (Ondo Tokenized)",
+    "address": "0xae1c6E353cdc9Dc3CC01124FFB62a0d0Ce64a401",
+    "symbol": "RMBSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rmbson_160x160.png"
+  },
+  {
+    "name": "Arteris (Ondo Tokenized)",
+    "address": "0x0D8EF471a11036Bc6dDa1536069457f7e97daB66",
+    "symbol": "AIPon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aipon_160x160.png"
+  },
+  {
+    "name": "Extreme Networks (Ondo Tokenized)",
+    "address": "0x04c8381e17b6A9245aBBF2e62c544eaEE4030D1b",
+    "symbol": "EXTRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/extron_160x160.png"
+  },
+  {
+    "name": "WhiteFiber (Ondo Tokenized)",
+    "address": "0xceb37aD46957047E22f726A7B25B134fC53AD753",
+    "symbol": "WYFIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wyfion_160x160.png"
+  },
+  {
+    "name": "Digi Power X (Ondo Tokenized)",
+    "address": "0xC76E008965b2f0E37896F52A2FEEe66EF2926ae8",
+    "symbol": "DGXXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dgxxon_160x160.png"
+  },
+  {
+    "name": "Bitdeer Technologies (Ondo Tokenized)",
+    "address": "0x0683154c33B7563ed39951B4d7C0470EA28D93e9",
+    "symbol": "BTDRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btdron_160x160.png"
+  },
+  {
+    "name": "Keel Infrastructure (Ondo Tokenized)",
+    "address": "0x96c662b152BEC886fAcab388bd98470FD3Aa9737",
+    "symbol": "KEELon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/keelon_160x160.png"
+  },
+  {
+    "name": "HIVE Digital Technologies (Ondo Tokenized)",
+    "address": "0x823cf9cCa5b8EAe0AE08fF3C6CD5102D2859DB4D",
+    "symbol": "HIVEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hiveon_160x160.png"
+  },
+  {
+    "name": "TTM Technologies (Ondo Tokenized)",
+    "address": "0xDEbb8E6F581655759e3D64f769247a007AF0aE36",
+    "symbol": "TTMIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ttmion_160x160.png"
+  },
+  {
+    "name": "Primoris Services (Ondo Tokenized)",
+    "address": "0xBa6FF85f4595a3E71F3a965E6B528bBcf51A2c79",
+    "symbol": "PRIMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/primon_160x160.png"
+  },
+  {
+    "name": "Lincoln Electric (Ondo Tokenized)",
+    "address": "0xD62C0Bf1e1dD6F4FEe1b3D042A9E479Ad1Fb1BCb",
+    "symbol": "LECOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lecoon_160x160.png"
+  },
+  {
+    "name": "AMETEK (Ondo Tokenized)",
+    "address": "0x113faE6e1103A4C09250C8697a6a4BE6Ca987d06",
+    "symbol": "AMEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ameon_160x160.png"
+  },
+  {
+    "name": "Forgent Power Solutions (Ondo Tokenized)",
+    "address": "0x410e7D6B6303E531753D4fbe3e50e35EfBcFf53c",
+    "symbol": "FPSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fpson_160x160.png"
+  },
+  {
+    "name": "WESCO International (Ondo Tokenized)",
+    "address": "0xF87efCA06f6Af53Cb096847bA092ccd04395A192",
+    "symbol": "WCCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wccon_160x160.png"
+  },
+  {
+    "name": "Breakwave Tanker Shipping ETF (Ondo Tokenized)",
+    "address": "0xEcA55ac71f83931B7e074228AEBc9104F13d8c02",
+    "symbol": "BWETon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bweton_160x160.png"
+  },
+  {
+    "name": "Scorpio Tankers (Ondo Tokenized)",
+    "address": "0xf25a149151033FcfAf069C1d007C3c2d2429bE8e",
+    "symbol": "STNGon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stngon_160x160.png"
+  },
+  {
+    "name": "Teekay Tankers (Ondo Tokenized)",
+    "address": "0x90c06Bccb5bd20c5a84cBD59A43Aa22cA96E588D",
+    "symbol": "TNKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tnkon_160x160.png"
+  },
+  {
+    "name": "International Seaways (Ondo Tokenized)",
+    "address": "0x3f696db88acA815c150fEb9baAa9870F85b77494",
+    "symbol": "INSWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inswon_160x160.png"
+  },
+  {
+    "name": "Tsakos Energy Navigation (Ondo Tokenized)",
+    "address": "0xdb2e166F0c76b05BC07700CbF74cC36Ae2603624",
+    "symbol": "TENon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tenon_160x160.png"
+  },
+  {
+    "name": "Nordic American Tankers (Ondo Tokenized)",
+    "address": "0x64b84731cEC441370C90c1b06d66A17EAdfAcd0F",
+    "symbol": "NATon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/naton_160x160.png"
+  },
+  {
+    "name": "Okeanis Eco Tankers (Ondo Tokenized)",
+    "address": "0xD081B43E3C334B1a101981efC1D98F1E82df076E",
+    "symbol": "ECOon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ecoon_160x160.png"
+  },
+  {
+    "name": "Westlake (Ondo Tokenized)",
+    "address": "0xEad51EE313a7187fc1a155C381270c764DA42770",
+    "symbol": "WLKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wlkon_160x160.png"
+  },
+  {
+    "name": "Nucor (Ondo Tokenized)",
+    "address": "0x167f8D6B357FA9fff9B1286E519Bd32d4504757E",
+    "symbol": "NUEon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nueon_160x160.png"
+  },
+  {
+    "name": "Steel Dynamics (Ondo Tokenized)",
+    "address": "0xf9D5aF26E1B96625dBC86609463A06602bE42966",
+    "symbol": "STLDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stldon_160x160.png"
+  },
+  {
+    "name": "Lattice Semiconductor (Ondo Tokenized)",
+    "address": "0xa0Db1eCa4AaEBCa03A3c04ed221b036Dd3CcB025",
+    "symbol": "LSCCon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lsccon_160x160.png"
+  },
+  {
+    "name": "CEVA (Ondo Tokenized)",
+    "address": "0xC4881Ce8269744B9255b926B76728eAdcB240A3B",
+    "symbol": "CEVAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cevaon_160x160.png"
+  },
+  {
+    "name": "Emerson Electric (Ondo Tokenized)",
+    "address": "0x26719965000A3DCAcc1451F836FbB9c883CCDe85",
+    "symbol": "EMRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/emron_160x160.png"
+  },
+  {
+    "name": "Symbotic (Ondo Tokenized)",
+    "address": "0x41d022C6008FbF431c5E5E88246A948B9E941EA3",
+    "symbol": "SYMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/symon_160x160.png"
+  },
+  {
+    "name": "TaskUs (Ondo Tokenized)",
+    "address": "0x85bD7B075A9e0f6D7099dd750CEcd65CE57d4F44",
+    "symbol": "TASKon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/taskon_160x160.png"
+  },
+  {
+    "name": "Innodata (Ondo Tokenized)",
+    "address": "0x1C99a152e00a5dc40f8c3e893C1d04b0F6a48B0f",
+    "symbol": "INODon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inodon_160x160.png"
+  },
+  {
+    "name": "Hesai Group (Ondo Tokenized)",
+    "address": "0xdC7E54dd476812F7cf1d77066f523aFE50eDAb1b",
+    "symbol": "HSAIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hsaion_160x160.png"
+  },
+  {
+    "name": "United States Antimony (Ondo Tokenized)",
+    "address": "0x084A613FEd04B5d26672E38dc9c3aa13f3C1AE58",
+    "symbol": "UAMYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uamyon_160x160.png"
+  },
+  {
+    "name": "REalloys (Ondo Tokenized)",
+    "address": "0x4cDd1099146f28a9b428CD85F36B562B6d05c8c8",
+    "symbol": "ALOYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aloyon_160x160.png"
+  },
+  {
+    "name": "ACM Research (Ondo Tokenized)",
+    "address": "0x8379c5595b8148A9968bEE6D8110B2b4a627a9Dd",
+    "symbol": "ACMRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/acmron_160x160.png"
+  },
+  {
+    "name": "Nova (Ondo Tokenized)",
+    "address": "0x80d04221eC124850C4B9ba8f625b9a12AD609200",
+    "symbol": "NVMIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvmion_160x160.png"
+  },
+  {
+    "name": "Amkor Technology (Ondo Tokenized)",
+    "address": "0xF02b8309df07641dDcFd1DABCeFFDde3d30915De",
+    "symbol": "AMKRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amkron_160x160.png"
+  },
+  {
+    "name": "AAON (Ondo Tokenized)",
+    "address": "0x6E9C573e5b8A59CEC47D8E317C148E4b0595FB39",
+    "symbol": "AAONon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aaonon_160x160.png"
+  },
+  {
+    "name": "Harmonic (Ondo Tokenized)",
+    "address": "0xa4daA3f53405BEa3B1E5701b6Db2DDC0efc4C8b2",
+    "symbol": "HLITon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hliton_160x160.png"
+  },
+  {
+    "name": "Roundhill Memory ETF (Ondo Tokenized)",
+    "address": "0xdB5a8f5B4C17f2Ee2e7192A150687E48eB3C415d",
+    "symbol": "DRAMon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dramon_160x160.png"
+  },
+  {
+    "name": "Global X MSCI Argentina ETF (Ondo Tokenized)",
+    "address": "0xfb1b703B26957C344aAb03BBE11EC9C23E9eDdf5",
+    "symbol": "ARGTon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/argton_160x160.png"
+  },
+  {
+    "name": "Hyperliquid Strategies (Ondo Tokenized)",
+    "address": "0x211d1d372E6A782e9786b045004382834bDB224e",
+    "symbol": "PURRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/purron_160x160.png"
+  },
+  {
+    "name": "Global X Defense Tech ETF (Ondo Tokenized)",
+    "address": "0xFb4Aa24c9c4E65f82d57d268dA8a65a0dE0DC43B",
+    "symbol": "SHLDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shldon_160x160.png"
+  },
+  {
+    "name": "Global X Robotics & Artificial Intelligence ETF (Ondo Tokenized)",
+    "address": "0x7AbeC847A3f9820397C82E1DAd231721Bf5a6732",
+    "symbol": "BOTZon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/botzon_160x160.png"
+  },
+  {
+    "name": "Global X Lithium & Battery Tech ETF (Ondo Tokenized)",
+    "address": "0x3EB4293B73080214012DeF05244eC291094C6C14",
+    "symbol": "LITon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/liton_160x160.png"
+  },
+  {
+    "name": "Global X Data Center & Digital Infrastructure ETF (Ondo Tokenized)",
+    "address": "0x4D9216151Dad1AF871A6EeC623e2F04E7a2717b3",
+    "symbol": "DTCRon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dtcron_160x160.png"
+  },
+  {
+    "name": "Global X Space Tech ETF (Ondo Tokenized)",
+    "address": "0xf8fd3698cA42c07f502150C19DD1D96B687f53Cd",
+    "symbol": "ORBXon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/orbxon_160x160.png"
+  },
+  {
+    "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF (Ondo Tokenized)",
+    "address": "0x34B33399a629fEd8EDC216EEb76C8309024C8987",
+    "symbol": "EUHYon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/euhyon_160x160.png"
+  },
+  {
+    "name": "iShares J.P. Morgan EM Local Currency Bond ETF (Ondo Tokenized)",
+    "address": "0xd9E7C53205048F83859815852616cd65D87AA83E",
+    "symbol": "LEMBon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lembon_160x160.png"
+  },
+  {
+    "name": "iShares Defense Industrials Active ETF (Ondo Tokenized)",
+    "address": "0x927dB66Cd5B55E9Df22d1D2207fBF059915240bB",
+    "symbol": "IDEFon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/idefon_160x160.png"
+  },
+  {
+    "name": "iShares Global Government Bond USD Hedged Active ETF (Ondo Tokenized)",
+    "address": "0xfBd7880EBC5c2b1B871a8CE188C05311015139F4",
+    "symbol": "GGOVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ggovon_160x160.png"
+  },
+  {
+    "name": "Global X NASDAQ 100 Covered Call ETF (Ondo Tokenized)",
+    "address": "0xA7776B3d801A6626807E0Db357C7EE2a8962903b",
+    "symbol": "QYLDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qyldon_160x160.png"
+  },
+  {
+    "name": "Global X Silver Miners ETF (Ondo Tokenized)",
+    "address": "0x603E505799511155A9216D37cF9e051171240b4c",
+    "symbol": "SILon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/silon_160x160.png"
+  },
+  {
+    "name": "Global X Artificial Intelligence & Technology ETF (Ondo Tokenized)",
+    "address": "0x2A5ae1BdE731cb8732fD762073DD0bBE151360B9",
+    "symbol": "AIQon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aiqon_160x160.png"
+  },
+  {
+    "name": "Global X Blockchain ETF (Ondo Tokenized)",
+    "address": "0xDd00b1046692aA2780ef04849829609Fc4F90fD7",
+    "symbol": "BKCHon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bkchon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI EAFE Value ETF (Ondo Tokenized)",
+    "address": "0x1252c5fa0a4031F6843D5Cf8d4986Ba99a8A9b42",
+    "symbol": "EFVon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/efvon_160x160.png"
+  },
+  {
+    "name": "iShares S&P Small-Cap 600 Value ETF (Ondo Tokenized)",
+    "address": "0xc0e1F30E45da2dced2c35D89947C20bffBa6f529",
+    "symbol": "IJSon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ijson_160x160.png"
+  },
+  {
+    "name": "iShares US Technology ETF (Ondo Tokenized)",
+    "address": "0x1577D4ae114B6F217453b754AeaC164db44832DA",
+    "symbol": "IYWon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iywon_160x160.png"
+  },
+  {
+    "name": "Global X S&P 500 Covered Call ETF (Ondo Tokenized)",
+    "address": "0x034c9ffeC64597E0a0622ca5B9eAF00839052e0a",
+    "symbol": "XYLDon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xyldon_160x160.png"
+  },
+  {
+    "name": "SPDR Bloomberg 1-3 Month T-Bill ETF (Ondo Tokenized)",
+    "address": "0x2710E30d84B376c34a3B3036aa196b26a83A321b",
+    "symbol": "BILon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bilon_160x160.png"
+  },
+  {
+    "name": "iShares 3-7 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "0xe905C437A30AE6d8c0576E0D9F6360B93B94976D",
+    "symbol": "IEIon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ieion_160x160.png"
+  },
+  {
+    "name": "AB Ultra Short Income ETF (Ondo Tokenized)",
+    "address": "0x5f24DD5DDb74bFe2BFE592aD91DBA09347031afd",
+    "symbol": "YEARon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/yearon_160x160.png"
+  },
+  {
+    "name": "Strive Preferred (Ondo Tokenized)",
+    "address": "0x141196732cE4BB20010E4149704C0F278d5d3CEA",
+    "symbol": "SATAon",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sataon_160x160.png"
   }
 ]

--- a/tokens/HYP.json
+++ b/tokens/HYP.json
@@ -246,5 +246,197 @@
     "decimals": 18,
     "name": "Moderna xStock",
     "symbol": "MRNAx"
+  },
+  {
+    "name": "Apple (Ondo Tokenized)",
+    "address": "0x81db0DF77669b3BE563e7a0591685a2C8C3EE1c5",
+    "symbol": "AAPLon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aaplon_160x160.png"
+  },
+  {
+    "name": "AMD (Ondo Tokenized)",
+    "address": "0x33706203A7a7c82B6F6c09dd9Ae4E6e881d36386",
+    "symbol": "AMDon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amdon_160x160.png"
+  },
+  {
+    "name": "Amazon (Ondo Tokenized)",
+    "address": "0xeD68F063264a01fd7f93087DC19CC1E0D614e8De",
+    "symbol": "AMZNon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amznon_160x160.png"
+  },
+  {
+    "name": "Alibaba (Ondo Tokenized)",
+    "address": "0x799Bf997B733CAb2e1377D0411b63E35133991eb",
+    "symbol": "BABAon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/babaon_160x160.png"
+  },
+  {
+    "name": "Coinbase (Ondo Tokenized)",
+    "address": "0x639Bcd00422facAcA534063e3d860e8fcf78B46F",
+    "symbol": "COINon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coinon_160x160.png"
+  },
+  {
+    "name": "Circle Internet Group (Ondo Tokenized)",
+    "address": "0x13a81c5e8b4AB05Fc721DfF7bA95e250b29458F8",
+    "symbol": "CRCLon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crclon_160x160.png"
+  },
+  {
+    "name": "Alphabet Class A (Ondo Tokenized)",
+    "address": "0x4D34798f18Eb747F7225663F0553eA2D880cf75D",
+    "symbol": "GOOGLon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/googlon_160x160.png"
+  },
+  {
+    "name": "Robinhood Markets (Ondo Tokenized)",
+    "address": "0xF1Df92AC8E22763A16bf4Bd9a966EEBcD70fA5a3",
+    "symbol": "HOODon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hoodon_160x160.png"
+  },
+  {
+    "name": "iShares Gold Trust (Ondo Tokenized)",
+    "address": "0x83b01AC9e2D1632A70Dd1C813c5B8eDF29cd707f",
+    "symbol": "IAUon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iauon_160x160.png"
+  },
+  {
+    "name": "Intel (Ondo Tokenized)",
+    "address": "0x7bf529bb5Db370D679F33f4fe5420F48eE234bB7",
+    "symbol": "INTCon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/intcon_160x160.png"
+  },
+  {
+    "name": "iShares Core S&P 500 ETF (Ondo Tokenized)",
+    "address": "0xAd26B6048cc3682f67Fe4C829b7Ac99dbF95920e",
+    "symbol": "IVVon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ivvon_160x160.png"
+  },
+  {
+    "name": "Meta Platforms (Ondo Tokenized)",
+    "address": "0x46FA18Ffe2707bbecc46D457D40EFBE6B932f711",
+    "symbol": "METAon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/metaon_160x160.png"
+  },
+  {
+    "name": "Microsoft (Ondo Tokenized)",
+    "address": "0xD53471f6D493f7eD766181D88Ba9c2Bfc371399A",
+    "symbol": "MSFTon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/msfton_160x160.png"
+  },
+  {
+    "name": "MicroStrategy (Ondo Tokenized)",
+    "address": "0x8a64FDf0857c1C734A594cd1DB20B3f8E3f133f6",
+    "symbol": "MSTRon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mstron_160x160.png"
+  },
+  {
+    "name": "Micron Technology (Ondo Tokenized)",
+    "address": "0x0f8E33F5CdefAE9C2E59de8fB61feD347046D046",
+    "symbol": "MUon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/muon_160x160.png"
+  },
+  {
+    "name": "Netflix (Ondo Tokenized)",
+    "address": "0x81Ebb420a81855f1Bf1B0fF95eCa9d3Bd736ea89",
+    "symbol": "NFLXon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nflxon_160x160.png"
+  },
+  {
+    "name": "NVIDIA (Ondo Tokenized)",
+    "address": "0xB989ad9b91886b1Aaed8DaADb26F028b29b40945",
+    "symbol": "NVDAon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvdaon_160x160.png"
+  },
+  {
+    "name": "Oracle (Ondo Tokenized)",
+    "address": "0x4775e99a13651B1D077c2fa04Eb9BF007f684af5",
+    "symbol": "ORCLon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/orclon_160x160.png"
+  },
+  {
+    "name": "Palantir Technologies (Ondo Tokenized)",
+    "address": "0x039358AB6919159f6026Ea4428595a5AaF12A35C",
+    "symbol": "PLTRon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pltron_160x160.png"
+  },
+  {
+    "name": "Invesco QQQ (Ondo Tokenized)",
+    "address": "0x911e2dCD2b70F44231F3F0f1C6ec9aF75068FD85",
+    "symbol": "QQQon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qqqon_160x160.png"
+  },
+  {
+    "name": "iShares Silver Trust (Ondo Tokenized)",
+    "address": "0xd53d98d13D93C817011645442c2e4d46E499B460",
+    "symbol": "SLVon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/slvon_160x160.png"
+  },
+  {
+    "name": "SPDR S&P 500 ETF (Ondo Tokenized)",
+    "address": "0x32eC2792aeC02122eDD9f28866B720db1e1c1B54",
+    "symbol": "SPYon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spyon_160x160.png"
+  },
+  {
+    "name": "Tesla (Ondo Tokenized)",
+    "address": "0x417883b1709545f1211A25b00ad13455fC7F1bc5",
+    "symbol": "TSLAon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tslaon_160x160.png"
+  },
+  {
+    "name": "Taiwan Semiconductor Manufacturing (Ondo Tokenized)",
+    "address": "0x3254cdffDDEDdb1F61B9eF6f67e178615CCb0E85",
+    "symbol": "TSMon",
+    "decimals": 18,
+    "chainId": 999,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tsmon_160x160.png"
   }
 ]

--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -166,5 +166,3205 @@
     "decimals": 6,
     "name": "Ondo US Dollar Yield",
     "logoURI": "https://coin-images.coingecko.com/coins/images/31700/large/usdy_%281%29.png?1696530524"
+  },
+  {
+    "name": "Ondo U.S. Dollar Token",
+    "address": "ZPFtoCe7WWqG4N3ZFRccS8T9SMBeHsd1Vmgv2i7ondo",
+    "symbol": "USDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usdon_160x160.png"
+  },
+  {
+    "name": "American Airlines Group (Ondo Tokenized)",
+    "address": "9wYZetvT8J2ptfsRca5gzLBGvcUug38mp9yT3xaondo",
+    "symbol": "AALon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aalon_160x160.png"
+  },
+  {
+    "name": "Apple (Ondo Tokenized)",
+    "address": "123mYEnRLM2LLYsJW3K6oyYh8uP1fngj732iG638ondo",
+    "symbol": "AAPLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aaplon_160x160.png"
+  },
+  {
+    "name": "AbbVie (Ondo Tokenized)",
+    "address": "MFerpBVGKZh2jXN7cbJdXRXQTp6j6pbSnSZrfWrondo",
+    "symbol": "ABBVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abbvon_160x160.png"
+  },
+  {
+    "name": "Airbnb (Ondo Tokenized)",
+    "address": "128qNYovdGv2YqayErcJgU7gDwbNVX1VuoxbtWz8ondo",
+    "symbol": "ABNBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abnbon_160x160.png"
+  },
+  {
+    "name": "Abbott (Ondo Tokenized)",
+    "address": "129gRoHKhVg7CvPMrqVsEB4uYZo6zV4yDZX6NBg9ondo",
+    "symbol": "ABTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/abton_160x160.png"
+  },
+  {
+    "name": "Archer Aviation (Ondo Tokenized)",
+    "address": "KcCVQxG9LhFYP5o9DWFKTFgFShPPQkDEemVbiFyondo",
+    "symbol": "ACHRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/achron_160x160.png"
+  },
+  {
+    "name": "Accenture (Ondo Tokenized)",
+    "address": "12LxMMJYVSf4LoeqjFE47BQQNRciaH9E3nbDfjH4ondo",
+    "symbol": "ACNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/acnon_160x160.png"
+  },
+  {
+    "name": "Adobe (Ondo Tokenized)",
+    "address": "12Rh6JhfW4X5fKP16bbUdb4pcVCKDHFB48x8GG33ondo",
+    "symbol": "ADBEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/adbeon_160x160.png"
+  },
+  {
+    "name": "Analog Devices (Ondo Tokenized)",
+    "address": "LmTMwmZLNZszn3qpjmnbhfP12U4qWDivaEBwSBSondo",
+    "symbol": "ADIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/adion_160x160.png"
+  },
+  {
+    "name": "iShares Core US Aggregate Bond ETF (Ondo Tokenized)",
+    "address": "13qTjKx53y6LKGGStiKeieGbnVx3fx1bbwopKFb3ondo",
+    "symbol": "AGGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aggon_160x160.png"
+  },
+  {
+    "name": "Albemarle (Ondo Tokenized)",
+    "address": "B5KufqHkskgGYwMXtL8FSHgREAkMQvE3ykhH5Kmondo",
+    "symbol": "ALBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/albon_160x160.png"
+  },
+  {
+    "name": "Applied Materials (Ondo Tokenized)",
+    "address": "7eRX747PSbVtGVx3qD5UFdkNM2BfTy86ikUiCMhondo",
+    "symbol": "AMATon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amaton_160x160.png"
+  },
+  {
+    "name": "AMC Entertainment (Ondo Tokenized)",
+    "address": "C9xNaNujcF1a5fidWAAFReFYqhLRVbyk4yPyGqzondo",
+    "symbol": "AMCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amcon_160x160.png"
+  },
+  {
+    "name": "AMD (Ondo Tokenized)",
+    "address": "14diAn5z8kjrKwSC8WLqvBqqe5YmihJhjxRxd8Z6ondo",
+    "symbol": "AMDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amdon_160x160.png"
+  },
+  {
+    "name": "Amgen (Ondo Tokenized)",
+    "address": "SS6AEWhzRrxhL2cXzKKjhFt3rCzmHHGKmFyugDTondo",
+    "symbol": "AMGNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amgnon_160x160.png"
+  },
+  {
+    "name": "Amazon (Ondo Tokenized)",
+    "address": "14Tqdo8V1FhzKsE3W2pFsZCzYPQxxupXRcqw9jv6ondo",
+    "symbol": "AMZNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amznon_160x160.png"
+  },
+  {
+    "name": "Arista Networks (Ondo Tokenized)",
+    "address": "Cq6QtvHpXbJWtFaiMhUDtHy8YVZ95gcD1oZ1cohondo",
+    "symbol": "ANETon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aneton_160x160.png"
+  },
+  {
+    "name": "Applied Digital (Ondo Tokenized)",
+    "address": "B6WqvLGXdGqpw7qgxeb5EGiRZEYo2apWpQybjYuondo",
+    "symbol": "APLDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/apldon_160x160.png"
+  },
+  {
+    "name": "Apollo Global Management (Ondo Tokenized)",
+    "address": "14VXAhoa1R74vi1ZuiQyGLJrnDMfoFBPJSCpGVz3ondo",
+    "symbol": "APOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/apoon_160x160.png"
+  },
+  {
+    "name": "AppLovin (Ondo Tokenized)",
+    "address": "14Z8rQQe2Aza33YgEUmj3g3QGNz8DXLiFPuCnsD1ondo",
+    "symbol": "APPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/appon_160x160.png"
+  },
+  {
+    "name": "Arm Holdings plc (Ondo Tokenized)",
+    "address": "15SsCZqCsM9fZGhTmP4rdJTPT9WGZKazDSsgeQ8ondo",
+    "symbol": "ARMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/armon_160x160.png"
+  },
+  {
+    "name": "ASML Holding NV (Ondo Tokenized)",
+    "address": "1eLZPRsn8bAKmoxsqDMH9Q2m2k7GMNp6RLSQGm8ondo",
+    "symbol": "ASMLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/asmlon_160x160.png"
+  },
+  {
+    "name": "AST SpaceMobile (Ondo Tokenized)",
+    "address": "B6ry9goGNvVbhq7gWHzs3p6emJ1gLaMhu4By9TTondo",
+    "symbol": "ASTSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/astson_160x160.png"
+  },
+  {
+    "name": "Broadcom (Ondo Tokenized)",
+    "address": "1FWZtdWN7y38BSXGzbs8D6Shk88oL9atDNgbVz9ondo",
+    "symbol": "AVGOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/avgoon_160x160.png"
+  },
+  {
+    "name": "American Express (Ondo Tokenized)",
+    "address": "1WxT6NdK7uqpfXuKpALxL2n3f7Rq61XXeHA8UM4ondo",
+    "symbol": "AXPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/axpon_160x160.png"
+  },
+  {
+    "name": "Alibaba (Ondo Tokenized)",
+    "address": "1zvb9ELBFShBCWKEk5jRTJAaPAwtVt7quEXx1X4ondo",
+    "symbol": "BABAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/babaon_160x160.png"
+  },
+  {
+    "name": "Bank of America (Ondo Tokenized)",
+    "address": "Wk8gC6iTNp8dqd4ghkJ3h1giiUnyhykwHh7tYWjondo",
+    "symbol": "BACon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bacon_160x160.png"
+  },
+  {
+    "name": "Boeing (Ondo Tokenized)",
+    "address": "1YVZ4LGpq8CAhpdpm3mgy7GgPb83gJczCpxLUQ3ondo",
+    "symbol": "BAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/baon_160x160.png"
+  },
+  {
+    "name": "BigBear.ai Holdings (Ondo Tokenized)",
+    "address": "YXE7mph6XhsgnyezkMEcTuohSuWhbLWfwx2Hh6mondo",
+    "symbol": "BBAIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bbaion_160x160.png"
+  },
+  {
+    "name": "Baidu (Ondo Tokenized)",
+    "address": "54CoRF2FYMZNJg9tS36xq5BUcLZ7rju1r59jGc2ondo",
+    "symbol": "BIDUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/biduon_160x160.png"
+  },
+  {
+    "name": "Bilibili (Ondo Tokenized)",
+    "address": "14kLsQVmc64qZexYuR4XGop9y8BeMkd77pJUm1Rhondo",
+    "symbol": "BILIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bilion_160x160.png"
+  },
+  {
+    "name": "iShares Flexible Income Active ETF (Ondo Tokenized)",
+    "address": "mhZ69E1vDnAsQJXAwarLYSX5tmgeMajXBJ2rXAcondo",
+    "symbol": "BINCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bincon_160x160.png"
+  },
+  {
+    "name": "Blackrock, Inc. (Ondo Tokenized)",
+    "address": "5H1VpMzRuoNtRbPTRCz35ETtEUtnkt8hJuQb9v7ondo",
+    "symbol": "BLKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blkon_160x160.png"
+  },
+  {
+    "name": "Bullish (Ondo Tokenized)",
+    "address": "A9PFmw9Hu8zzxDUoU351pio1E1XWBWBfWnjT9qoondo",
+    "symbol": "BLSHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blshon_160x160.png"
+  },
+  {
+    "name": "BitMine Immersion Technologies (Ondo Tokenized)",
+    "address": "MYXqkDYbzr7vjXAz2BapR4AiYRXzoikGirrLoRzondo",
+    "symbol": "BMNRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bmnron_160x160.png"
+  },
+  {
+    "name": "US Brent Oil Fund (Ondo Tokenized)",
+    "address": "BAU83kqEqhyiexfAMQhZZE5KnGogSqh17fJc44Sondo",
+    "symbol": "BNOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bnoon_160x160.png"
+  },
+  {
+    "name": "B2Gold (Ondo Tokenized)",
+    "address": "cBnVXDyZgaaLZM18wAmqsUKnRUFAEJWbq6VuUoaondo",
+    "symbol": "BTGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btgon_160x160.png"
+  },
+  {
+    "name": "Kanzhun (Ondo Tokenized)",
+    "address": "doPqjCxi6UkANkvMz5fSuYGEo5PGppVpTZMeB5vondo",
+    "symbol": "BZon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bzon_160x160.png"
+  },
+  {
+    "name": "Capricor Therapeutics (Ondo Tokenized)",
+    "address": "BS8zoc6pmALQnBhBDFak6eFhgGHjpebnHzsxApgondo",
+    "symbol": "CAPRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/capron_160x160.png"
+  },
+  {
+    "name": "First Trust NASDAQ Cybersecurity ETF (Ondo Tokenized)",
+    "address": "BVdL3WUxtxUD4vXRWwqChJLbGxvfzZjBGPp63Wtondo",
+    "symbol": "CIBRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cibron_160x160.png"
+  },
+  {
+    "name": "Chipotle (Ondo Tokenized)",
+    "address": "5owVsVFSHACQuippFYdLp3qWRobp2EGcwxMmsr6ondo",
+    "symbol": "CMGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cmgon_160x160.png"
+  },
+  {
+    "name": "Coherent (Ondo Tokenized)",
+    "address": "BXMkru8ded26p71gJ3AMMwJmwZaYYfQjRo8vbZzondo",
+    "symbol": "COHRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cohron_160x160.png"
+  },
+  {
+    "name": "Coinbase (Ondo Tokenized)",
+    "address": "5u6KDiNJXxX4rGMfYT4BApZQC5CuDNrG6MHkwp1ondo",
+    "symbol": "COINon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coinon_160x160.png"
+  },
+  {
+    "name": "ConocoPhillips (Ondo Tokenized)",
+    "address": "X68p9qTpEMkR1TLpXUP2ZJo8PG4Qge2Y2ZLdjA2ondo",
+    "symbol": "COPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/copon_160x160.png"
+  },
+  {
+    "name": "Global X Copper Miners ETF (Ondo Tokenized)",
+    "address": "X7j77hTmjZJbepkXXBcsEapM8qNgdfihkFj6CZ5ondo",
+    "symbol": "COPXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/copxon_160x160.png"
+  },
+  {
+    "name": "Costco (Ondo Tokenized)",
+    "address": "6btaz134wjHkR8sqhAYrtSM6tavftfxnRvnyMd8ondo",
+    "symbol": "COSTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coston_160x160.png"
+  },
+  {
+    "name": "Coupang (Ondo Tokenized)",
+    "address": "NKyzy31w2J7odLb2CW3Ft4fpKXkW3LBt1pvpkVLondo",
+    "symbol": "CPNGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cpngon_160x160.png"
+  },
+  {
+    "name": "Circle Internet Group (Ondo Tokenized)",
+    "address": "6xHEyem9hmkGtVq6XGCiQUGpPsHBaoYuYdFNZa5ondo",
+    "symbol": "CRCLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crclon_160x160.png"
+  },
+  {
+    "name": "Salesforce (Ondo Tokenized)",
+    "address": "7D7ukbcnUNYt7Et5vtsDZhAy28MKu9pkHka1Hp9ondo",
+    "symbol": "CRMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crmon_160x160.png"
+  },
+  {
+    "name": "CrowdStrike (Ondo Tokenized)",
+    "address": "cdKfoNjbXgnSuxvoajhtH3uixfZhq1YXhQsS1Rwondo",
+    "symbol": "CRWDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crwdon_160x160.png"
+  },
+  {
+    "name": "CoreWeave (Ondo Tokenized)",
+    "address": "BfPGpgNyxe6rjAru1EJarjSBAcCABuMF5L32v7nondo",
+    "symbol": "CRWVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crwvon_160x160.png"
+  },
+  {
+    "name": "Cisco Systems (Ondo Tokenized)",
+    "address": "7DWcZE1uVc8m2mf9pV8KNov28ET7HsvHkhrhgr9ondo",
+    "symbol": "CSCOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cscoon_160x160.png"
+  },
+  {
+    "name": "Carvana (Ondo Tokenized)",
+    "address": "FGmUDXqA3AbWfo5b3NUcsvwoUFCF4tr9ea6uercondo",
+    "symbol": "CVNAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cvnaon_160x160.png"
+  },
+  {
+    "name": "Chevron (Ondo Tokenized)",
+    "address": "7tgKziACteG26VjV5xKufojKxwTgCFyTwmWUmz5ondo",
+    "symbol": "CVXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cvxon_160x160.png"
+  },
+  {
+    "name": "DoorDash (Ondo Tokenized)",
+    "address": "83P1gCFBZfGRCwJuBt9juxJKEsZwejJoG66eTZ6ondo",
+    "symbol": "DASHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dashon_160x160.png"
+  },
+  {
+    "name": "Invesco DB Commodity Index Tracking Fund (Ondo Tokenized)",
+    "address": "td1aY5AvYQuwGD75qNq9aPipMexraN9mQXJwqifondo",
+    "symbol": "DBCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dbcon_160x160.png"
+  },
+  {
+    "name": "Deere (Ondo Tokenized)",
+    "address": "CqQyAZjB9LGFTG95eiadGTkfhd9QA12ProeKsQmondo",
+    "symbol": "DEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/deon_160x160.png"
+  },
+  {
+    "name": "WisdomTree US Quality Dividend Growth Fund (Ondo Tokenized)",
+    "address": "gnoSQSNTNZHViqVfxCcPDVxcRA29mrJL7C6JqYLondo",
+    "symbol": "DGRWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dgrwon_160x160.png"
+  },
+  {
+    "name": "Disney (Ondo Tokenized)",
+    "address": "mJf1xT3suXtkXBCfZcE9oUUuyxkvSgqYBWiX7v1ondo",
+    "symbol": "DISon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dison_160x160.png"
+  },
+  {
+    "name": "Denison Mines (Ondo Tokenized)",
+    "address": "12J2LD3tuLfdiVKnWZMHRMrbnXDY9rM4yqVLUa5yondo",
+    "symbol": "DNNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dnnon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Chile ETF (Ondo Tokenized)",
+    "address": "BmXVAFyfpW7VuVYeWDtbFtLx7sek2mZt3BEsGgAondo",
+    "symbol": "ECHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/echon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Emerging Markets ETF (Ondo Tokenized)",
+    "address": "916SDKz7y5ZcEZC9CtnQ5Djs1Y8Yv3UAPb6bak8ondo",
+    "symbol": "EEMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/eemon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI EAFE ETF (Ondo Tokenized)",
+    "address": "AbvryMGnaba9oADMZk8Vp2Av6MtczsncGyfWaC4ondo",
+    "symbol": "EFAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/efaon_160x160.png"
+  },
+  {
+    "name": "Enlivex Therapeutics (Ondo Tokenized)",
+    "address": "BncvtBGs4JqgYZwUoq3EN9q9HUFqJKTfWpvCsHCondo",
+    "symbol": "ENLVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enlvon_160x160.png"
+  },
+  {
+    "name": "Enphase Energy (Ondo Tokenized)",
+    "address": "Bp26APthMuM46gMFTo5KYpo7b92GN2xSCor7f9oondo",
+    "symbol": "ENPHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enphon_160x160.png"
+  },
+  {
+    "name": "Equinix (Ondo Tokenized)",
+    "address": "aheEdmuryJU8ymy8LjYheZH5i2BW1UMsfuWQKD2ondo",
+    "symbol": "EQIXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/eqixon_160x160.png"
+  },
+  {
+    "name": "iShares Ethereum Trust (Ondo Tokenized)",
+    "address": "LitNUakTges74cjDJm6HHfFNKGPdySkp3MWSYzYondo",
+    "symbol": "ETHAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ethaon_160x160.png"
+  },
+  {
+    "name": "Eaton (Ondo Tokenized)",
+    "address": "BpYiU1dBXU1fdB64jbR93wHEw3Y47QeRLZvUyLQondo",
+    "symbol": "ETNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/etnon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Japan ETF (Ondo Tokenized)",
+    "address": "C6c7VcxuUYcV5YTsky5HM4PUmfwHTwsDD5DNwwPondo",
+    "symbol": "EWJon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewjon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI South Korea ETF (Ondo Tokenized)",
+    "address": "C8pSaSgjkiTWixS3GM6Hxd6HKnKrgAbY9WDgfVeondo",
+    "symbol": "EWYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewyon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI Brazil ETF (Ondo Tokenized)",
+    "address": "CBKcmEvVg5EgE3W5hVSPcBYWh6TFVjQwbmYod9Pondo",
+    "symbol": "EWZon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ewzon_160x160.png"
+  },
+  {
+    "name": "Exodus Movement (Ondo Tokenized)",
+    "address": "CJRoTbu98waCCuLFfLuJ2kXawLk889fqW4UAAbwondo",
+    "symbol": "EXODon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/exodon_160x160.png"
+  },
+  {
+    "name": "Freeport-McMoRan (Ondo Tokenized)",
+    "address": "CY8ttw5rYCT6fFBJwqXofefqa7Ji9E8zfLmhRLmondo",
+    "symbol": "FCXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fcxon_160x160.png"
+  },
+  {
+    "name": "Franklin Focused Growth ETF (Ondo Tokenized)",
+    "address": "CYAwMGyuNSDu7NpuccNwcxMNS5Bu9akxU2Jooyiondo",
+    "symbol": "FFOGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ffogon_160x160.png"
+  },
+  {
+    "name": "Franklin Responsibly Sourced Gold ETF (Ondo Tokenized)",
+    "address": "CYqLHM92EhmF83iNgfN4A1j2ckjsHigRvXu7xHCondo",
+    "symbol": "FGDLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fgdlon_160x160.png"
+  },
+  {
+    "name": "Figma (Ondo Tokenized)",
+    "address": "aLDdFsr3VTUQaHFK6yNvQxztvxQ8nxW4AMuSGC7ondo",
+    "symbol": "FIGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/figon_160x160.png"
+  },
+  {
+    "name": "Franklin High Yield Corporate ETF (Ondo Tokenized)",
+    "address": "CZ3FxxSto7tsjkSkqMek1C5p3RCFFmkwKqW57nbondo",
+    "symbol": "FLHYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flhyon_160x160.png"
+  },
+  {
+    "name": "Franklin US Large Cap Multifactor Index ETF (Ondo Tokenized)",
+    "address": "CZ9GBn1okotqKNUUqoxk4PF2JVi59bw5GWvVo6Dondo",
+    "symbol": "FLQLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flqlon_160x160.png"
+  },
+  {
+    "name": "Fidelity Solana Fund (Ondo Tokenized)",
+    "address": "BJhPr9SM7uZTZXHeSLYmUk7CjGQq1esFkVxPF5tondo",
+    "symbol": "FSOLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fsolon_160x160.png"
+  },
+  {
+    "name": "First Trust Global Tactical Commodity Strategy Fund (Ondo Tokenized)",
+    "address": "ivBnfPTyuHDNWmMSnbavckhJK6SHZW8h77nZKsEondo",
+    "symbol": "FTGCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ftgcon_160x160.png"
+  },
+  {
+    "name": "Futu Holdings (Ondo Tokenized)",
+    "address": "Ao5rKFRQ54W3DKSAtqfhBRPNHewwWRLNLao2JL9ondo",
+    "symbol": "FUTUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/futuon_160x160.png"
+  },
+  {
+    "name": "iShares China Large-Cap ETF (Ondo Tokenized)",
+    "address": "CeFbGYXDmkyfo1TXXzzZ512mtnCCewNohu6V15vondo",
+    "symbol": "FXIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fxion_160x160.png"
+  },
+  {
+    "name": "Gemini Space Station (Ondo Tokenized)",
+    "address": "NrTdGMA3ujUvWXkwXyZKnhoByb32KTjRh5Vo47yondo",
+    "symbol": "GEMIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gemion_160x160.png"
+  },
+  {
+    "name": "General Electric (Ondo Tokenized)",
+    "address": "aTBfDuLRqYHBiG82bHA7DzwjSDTFre2dRtGH3S5ondo",
+    "symbol": "GEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/geon_160x160.png"
+  },
+  {
+    "name": "GE Vernova (Ondo Tokenized)",
+    "address": "CgZSv89BL58ybWfWobANKEU8nV9jYfFw23G2DZEondo",
+    "symbol": "GEVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gevon_160x160.png"
+  },
+  {
+    "name": "SPDR Gold Shares (Ondo Tokenized)",
+    "address": "hWfiw4mcxT8rnNFkk6fsCQSxoxgZ9yVhB6tyeVcondo",
+    "symbol": "GLDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gldon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Precious Metals Basket Shares ETF (Ondo Tokenized)",
+    "address": "CgnZbDNzBfaLyJqUtd4esKLShRp7RznQuwP4uQaondo",
+    "symbol": "GLTRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gltron_160x160.png"
+  },
+  {
+    "name": "Galaxy Digital (Ondo Tokenized)",
+    "address": "CkWmEM2J79k6AjAwyQVHXteFucAL1zQrKLxLqJHondo",
+    "symbol": "GLXYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/glxyon_160x160.png"
+  },
+  {
+    "name": "GameStop (Ondo Tokenized)",
+    "address": "aznKt8v32CwYMEcTcB4bGTv8DXWStCpHrcCtyy7ondo",
+    "symbol": "GMEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gmeon_160x160.png"
+  },
+  {
+    "name": "Alphabet Class A (Ondo Tokenized)",
+    "address": "bbahNA5vT9WJeYft8tALrH1LXWffjwqVoUbqYa1ondo",
+    "symbol": "GOOGLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/googlon_160x160.png"
+  },
+  {
+    "name": "Grab Holdings (Ondo Tokenized)",
+    "address": "m9GcsVgdjaL3KsdtSFHimnhtsUMpTHkjtwEG4Tzondo",
+    "symbol": "GRABon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/grabon_160x160.png"
+  },
+  {
+    "name": "Goldman Sachs (Ondo Tokenized)",
+    "address": "BchJRy2snmhJZf3rQ9LJ3ePs2BGfYgfvQNo31d2ondo",
+    "symbol": "GSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gson_160x160.png"
+  },
+  {
+    "name": "Home Depot (Ondo Tokenized)",
+    "address": "MtEXKVN3Pcggy8MPA3eJr15H6SK3RXheScqj9qtondo",
+    "symbol": "HDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hdon_160x160.png"
+  },
+  {
+    "name": "Hims & Hers Health (Ondo Tokenized)",
+    "address": "bdh3njeo19d2TBLAKTGvCWdSoArfVw8uZBAJHY4ondo",
+    "symbol": "HIMSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/himson_160x160.png"
+  },
+  {
+    "name": "Robinhood Markets (Ondo Tokenized)",
+    "address": "BVdXGvmgi6A9oAiwWvBvP76fyTqcCNRJMM7zMN6ondo",
+    "symbol": "HOODon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hoodon_160x160.png"
+  },
+  {
+    "name": "iBoxx $ High Yield Corporate Bond ETF (Ondo Tokenized)",
+    "address": "c5ug15fwZRfQhhVa6LHscFY33ebVDHcVCezYpj7ondo",
+    "symbol": "HYGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hygon_160x160.png"
+  },
+  {
+    "name": "PIMCO 0-5 Year High Yield Corporate Bond Index ETF (Ondo Tokenized)",
+    "address": "CsN1Tyz467bSFLPGd6MJyZhPNtwDaWZtX8ixHWyondo",
+    "symbol": "HYSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hyson_160x160.png"
+  },
+  {
+    "name": "iShares Gold Trust (Ondo Tokenized)",
+    "address": "M77ZvkZ8zW5udRbuJCbuwSwavRa7bGAZYMTwru8ondo",
+    "symbol": "IAUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iauon_160x160.png"
+  },
+  {
+    "name": "iShares Bitcoin Trust (Ondo Tokenized)",
+    "address": "6JLG8iUkAuqiBhL3j2ckDMDf5oWAa6awmyaWezKondo",
+    "symbol": "IBITon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ibiton_160x160.png"
+  },
+  {
+    "name": "IBM (Ondo Tokenized)",
+    "address": "C8bZkgSxXkyT1RgxByp2teJ24hgimPLoyEYoNa9ondo",
+    "symbol": "IBMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ibmon_160x160.png"
+  },
+  {
+    "name": "iShares Core MSCI EAFE ETF (Ondo Tokenized)",
+    "address": "C9J9vZ8N79GzzxFoRkPWCkGtMKU8akg4FhUk4r9ondo",
+    "symbol": "IEFAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iefaon_160x160.png"
+  },
+  {
+    "name": "iShares 7-10 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "D4uWxzR5StYC6sTRhVts8Eboy3pmVtHeNC62dnQondo",
+    "symbol": "IEFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iefon_160x160.png"
+  },
+  {
+    "name": "iShares Core MSCI Emerging Markets ETF (Ondo Tokenized)",
+    "address": "cdVNL7wK8mf1UCDqM6zdrziRv4hmvqWhXeTcck2ondo",
+    "symbol": "IEMGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iemgon_160x160.png"
+  },
+  {
+    "name": "iShares Core S&P MidCap ETF (Ondo Tokenized)",
+    "address": "cfPLN9WXD2BTkbZhRZMVXPmVSiRo44hJWRtnaC8ondo",
+    "symbol": "IJHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ijhon_160x160.png"
+  },
+  {
+    "name": "Franklin Income Equity Focus ETF (Ondo Tokenized)",
+    "address": "D8KT4Jd8qiKKTfkM8ejSKCpWGR1o3GFvnQGp5ERondo",
+    "symbol": "INCEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inceon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI India ETF (Ondo Tokenized)",
+    "address": "DBNwt3FoYCKQWdfzxKFNZ4mzuz4Jz1iRzFf7HFzondo",
+    "symbol": "INDAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/indaon_160x160.png"
+  },
+  {
+    "name": "Intel (Ondo Tokenized)",
+    "address": "cJpUMp5R7rZ6fGeLHbHhrRuJzK9mkyKDjZqNpT3ondo",
+    "symbol": "INTCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/intcon_160x160.png"
+  },
+  {
+    "name": "Intuit (Ondo Tokenized)",
+    "address": "CozoH5HBTyyeYSQxHcWpGzd4Sq5XBaKzBzvTtN3ondo",
+    "symbol": "INTUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/intuon_160x160.png"
+  },
+  {
+    "name": "IonQ (Ondo Tokenized)",
+    "address": "DDZQijTbaSd3Kas1r1bgCnHPayk8vTP8SfZWp5Tondo",
+    "symbol": "IONQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ionqon_160x160.png"
+  },
+  {
+    "name": "Iren (Ondo Tokenized)",
+    "address": "13QHuepdhtJ3urNsV9i1hdL8nQoca2G7ZaLzb5FYondo",
+    "symbol": "IRENon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/irenon_160x160.png"
+  },
+  {
+    "name": "Intuitive Surgical (Ondo Tokenized)",
+    "address": "1MGRpPrkhEsCm2GCWD3rsvEU77xTTLAzfKXeFgFondo",
+    "symbol": "ISRGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/isrgon_160x160.png"
+  },
+  {
+    "name": "iShares US Aerospace and Defense ETF (Ondo Tokenized)",
+    "address": "DDcAL93Urf7KrPntvKULnZoFs4Wdee1LkkJqLpjondo",
+    "symbol": "ITAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/itaon_160x160.png"
+  },
+  {
+    "name": "iShares Core S&P Total US Stock Market ETF (Ondo Tokenized)",
+    "address": "CPWkMURVvcnX8hGjqCTb8i5LkzV3VSvyk7SeJi8ondo",
+    "symbol": "ITOTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/itoton_160x160.png"
+  },
+  {
+    "name": "iShares Core S&P 500 ETF (Ondo Tokenized)",
+    "address": "CqW2pd6dCPG9xKZfAsTovzDsMmAGKJSDBNcwM96ondo",
+    "symbol": "IVVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ivvon_160x160.png"
+  },
+  {
+    "name": "iShares Russell 1000 Growth ETF (Ondo Tokenized)",
+    "address": "dSHPFuMMjZqt7xDYGWrexXTSkdEZAiZngqymQF2ondo",
+    "symbol": "IWFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iwfon_160x160.png"
+  },
+  {
+    "name": "iShares Russell 2000 ETF (Ondo Tokenized)",
+    "address": "dvj2kKFSyjpnyYSYppgFdAEVfgjMEoQGi9VaV23ondo",
+    "symbol": "IWMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iwmon_160x160.png"
+  },
+  {
+    "name": "iShares Russell 2000 Value ETF (Ondo Tokenized)",
+    "address": "DX7g7WNjDpVzNK9CG81v7wb6ZbiNzYfkdzH2Xs5ondo",
+    "symbol": "IWNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iwnon_160x160.png"
+  },
+  {
+    "name": "Janus Henderson AAA CLO ETF (Ondo Tokenized)",
+    "address": "KZtqx9BJbpcGY7vdzhqPXM3ECKChxE5YhXaDiwRondo",
+    "symbol": "JAAAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jaaaon_160x160.png"
+  },
+  {
+    "name": "JD.com (Ondo Tokenized)",
+    "address": "E1aUS5nyv7kaBzdQzPVJW5zfaMgoUJpKYzdnFS2ondo",
+    "symbol": "JDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jdon_160x160.png"
+  },
+  {
+    "name": "Johnson & Johnson (Ondo Tokenized)",
+    "address": "KUXt7LzHWSQXp5eyqMZRxWjAP6yM8BUh4LRHwiwondo",
+    "symbol": "JNJon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jnjon_160x160.png"
+  },
+  {
+    "name": "JPMorgan Chase (Ondo Tokenized)",
+    "address": "E5Gczsavxcomqf6Cw1sGCKLabL1xYD2FzKxVoB4ondo",
+    "symbol": "JPMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jpmon_160x160.png"
+  },
+  {
+    "name": "KLA (Ondo Tokenized)",
+    "address": "149o8ppQf9SzKCKXZ4v3dzHkwumvtQSRzSEkr29uondo",
+    "symbol": "KLACon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/klacon_160x160.png"
+  },
+  {
+    "name": "Coca-Cola (Ondo Tokenized)",
+    "address": "e6G4pfFcrdKxJuZ4YXixRFfMbpMvgXG2Mjcus71ondo",
+    "symbol": "KOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/koon_160x160.png"
+  },
+  {
+    "name": "KraneShares CSI China Internet ETF (Ondo Tokenized)",
+    "address": "DVPSYdqWPLvNa8afnEqa3B9eDfTTWpGyUZeXvdMondo",
+    "symbol": "KWEBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/kwebon_160x160.png"
+  },
+  {
+    "name": "Linde plc (Ondo Tokenized)",
+    "address": "Edik9MoFp8LAXS9HNu2gRFyihwYqDqv4ZmNmVT9ondo",
+    "symbol": "LINon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/linon_160x160.png"
+  },
+  {
+    "name": "Li Auto (Ondo Tokenized)",
+    "address": "v12TwfofSbvVqQ5N5KGG4d3J8rtEi4BjGfn2apyondo",
+    "symbol": "LIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lion_160x160.png"
+  },
+  {
+    "name": "Eli Lilly (Ondo Tokenized)",
+    "address": "eGGxZwNSfuNKRqQLKaz2hc4QkA2mau7skyxPdj7ondo",
+    "symbol": "LLYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/llyon_160x160.png"
+  },
+  {
+    "name": "Lockheed (Ondo Tokenized)",
+    "address": "EoReHwUnGGekbXFHLj5rbCVKiwWqu32GrETMfw4ondo",
+    "symbol": "LMTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lmton_160x160.png"
+  },
+  {
+    "name": "Lowe's (Ondo Tokenized)",
+    "address": "edLdFJVVR532qhcrNTJjLAmhmyV7NsctbWVokMBondo",
+    "symbol": "LOWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lowon_160x160.png"
+  },
+  {
+    "name": "Lam Research (Ondo Tokenized)",
+    "address": "wFJoeEYpKg9oRhyJy6BWTT3J95gmXBLvoeikDQNondo",
+    "symbol": "LRCXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lrcxon_160x160.png"
+  },
+  {
+    "name": "Intuitive Machines (Ondo Tokenized)",
+    "address": "DiDWPZ7vQXfpaeQ8BX68XuDYeiQLv7diDxdeUpaondo",
+    "symbol": "LUNRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lunron_160x160.png"
+  },
+  {
+    "name": "Mastercard (Ondo Tokenized)",
+    "address": "EsVHcyRxXFJCLMiuYLWhoDygrNe1BJGpYeZ17X7ondo",
+    "symbol": "MAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/maon_160x160.png"
+  },
+  {
+    "name": "MARA Holdings (Ondo Tokenized)",
+    "address": "ETCJUmuhs5aY62xgEVWCZ5JR8KPdeXUaJz3LuC5ondo",
+    "symbol": "MARAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/maraon_160x160.png"
+  },
+  {
+    "name": "McDonald's (Ondo Tokenized)",
+    "address": "EUbJjmDt8JA222M91bVLZs211siZ2jzbFArH9N3ondo",
+    "symbol": "MCDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mcdon_160x160.png"
+  },
+  {
+    "name": "MercadoLibre (Ondo Tokenized)",
+    "address": "EWwdgGshGngcMpDV34pWZRSu5bkAuiKuKTTHKQ8ondo",
+    "symbol": "MELIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/melion_160x160.png"
+  },
+  {
+    "name": "Meta Platforms (Ondo Tokenized)",
+    "address": "fDxs5y12E7x7jBwCKBXGqt71uJmCWsAQ3Srkte6ondo",
+    "symbol": "METAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/metaon_160x160.png"
+  },
+  {
+    "name": "MP Materials (Ondo Tokenized)",
+    "address": "XwFm5GiKPVTvPiEbQpdc6vJbFEpsUXRMf6TcSxnondo",
+    "symbol": "MPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mpon_160x160.png"
+  },
+  {
+    "name": "Merck (Ondo Tokenized)",
+    "address": "bn1fb8dwzafGePqNPrM8m8cbAKQiFqeEPuZkPySondo",
+    "symbol": "MRKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrkon_160x160.png"
+  },
+  {
+    "name": "Moderna (Ondo Tokenized)",
+    "address": "14VP7DvCAdBCc5XGNZkPt6zhtPzJrWWS64Koxtxyondo",
+    "symbol": "MRNAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrnaon_160x160.png"
+  },
+  {
+    "name": "Marvell Technology (Ondo Tokenized)",
+    "address": "FovBwhoV5KQjZCdhoM6jgXYwXLX3F8vgAfvmLH7ondo",
+    "symbol": "MRVLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mrvlon_160x160.png"
+  },
+  {
+    "name": "Microsoft (Ondo Tokenized)",
+    "address": "FRmH6iRkMr33DLG6zVLR7EM4LojBFAuq6NtFzG6ondo",
+    "symbol": "MSFTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/msfton_160x160.png"
+  },
+  {
+    "name": "MicroStrategy (Ondo Tokenized)",
+    "address": "FSz4ouiqXpHuGPcpacZfTzbMjScoj5FfzHkiyu2ondo",
+    "symbol": "MSTRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mstron_160x160.png"
+  },
+  {
+    "name": "Micron Technology (Ondo Tokenized)",
+    "address": "Fz9edBpaURPPzpKVRR1A8PENYDEgHqwx5D5th28ondo",
+    "symbol": "MUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/muon_160x160.png"
+  },
+  {
+    "name": "Nebius Group (Ondo Tokenized)",
+    "address": "DiRshqNDE68bWbGdLHm1GwQ76MvWQG3af6w1NdQondo",
+    "symbol": "NBISon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nbison_160x160.png"
+  },
+  {
+    "name": "NextEra Energy (Ondo Tokenized)",
+    "address": "t7eN6cGwRMFaZvsNW2SmVwkedmHtDdrxA4ycNE5ondo",
+    "symbol": "NEEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/neeon_160x160.png"
+  },
+  {
+    "name": "Newmont (Ondo Tokenized)",
+    "address": "Dig28Tf1ufhCBAsjTmFkXCgcNgMqDMYj5A2rDQmondo",
+    "symbol": "NEMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nemon_160x160.png"
+  },
+  {
+    "name": "Netflix (Ondo Tokenized)",
+    "address": "g4KnPrxPLeeKkwvDmZFMtYQPM64eHeShbD55vK6ondo",
+    "symbol": "NFLXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nflxon_160x160.png"
+  },
+  {
+    "name": "Sprott Nickel Miners ETF (Ondo Tokenized)",
+    "address": "V8LRV7kWjrx6Prke9oHEHNUiR122BVtyuPciTCTondo",
+    "symbol": "NIKLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/niklon_160x160.png"
+  },
+  {
+    "name": "NIO (Ondo Tokenized)",
+    "address": "yQ37dFiGAbzrb2FRAEhGNzRy5zFfoYGWYhAepFEondo",
+    "symbol": "NIOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nioon_160x160.png"
+  },
+  {
+    "name": "Nike (Ondo Tokenized)",
+    "address": "g646pcdG2Rt5DH9WZzL7VVnVDWCCMTTrnktwE74ondo",
+    "symbol": "NKEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nkeon_160x160.png"
+  },
+  {
+    "name": "Northrop Grumman (Ondo Tokenized)",
+    "address": "Dm6FpQ76SsbVmAZ4NvD2mjZP7cxbw1CASr4WwCiondo",
+    "symbol": "NOCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nocon_160x160.png"
+  },
+  {
+    "name": "ServiceNow (Ondo Tokenized)",
+    "address": "G7pTVoSECz5RQWubEnTP7AC83KHUsSyoiqYR1R2ondo",
+    "symbol": "NOWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nowon_160x160.png"
+  },
+  {
+    "name": "NetEase (Ondo Tokenized)",
+    "address": "YeK2TdPtGLAme3Phg4pb1GBN2YxKgX5UNVyD4asondo",
+    "symbol": "NTESon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nteson_160x160.png"
+  },
+  {
+    "name": "Novo Nordisk (Ondo Tokenized)",
+    "address": "GeV7S8vjP8qdYZpdGv2Xi6e7MUMCk8NAAp2z7g5ondo",
+    "symbol": "NVOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvoon_160x160.png"
+  },
+  {
+    "name": "VanEck Oil Services ETF (Ondo Tokenized)",
+    "address": "DnvbCqRuUYssmKVRBRNwkUnptHitH4ZZTt1KVuZondo",
+    "symbol": "OIHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oihon_160x160.png"
+  },
+  {
+    "name": "Oklo (Ondo Tokenized)",
+    "address": "m6oDLvJT7rY7M1TxuLWP3pWmAPg2cCWDQR1NKiEondo",
+    "symbol": "OKLOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/okloon_160x160.png"
+  },
+  {
+    "name": "Ondas Holdings (Ondo Tokenized)",
+    "address": "7qy1j4Mechfyr6uAST3djH4vk4kiEYC2cjEytXdondo",
+    "symbol": "ONDSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ondson_160x160.png"
+  },
+  {
+    "name": "ON Semiconductor (Ondo Tokenized)",
+    "address": "13qtwy5fZi9Przz14pzo9xqFSr8QHmLyUpUCvP1xondo",
+    "symbol": "ONon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/onon_160x160.png"
+  },
+  {
+    "name": "Opendoor Technologies (Ondo Tokenized)",
+    "address": "ou1uE526v7zmUYP2qCb2LJgfXAyWAtWS9SETtr8ondo",
+    "symbol": "OPENon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/openon_160x160.png"
+  },
+  {
+    "name": "Opera (Ondo Tokenized)",
+    "address": "gbHFTMkuMQUy5xrgoCBdaQ2XYvNyjWAYcnRPh9Condo",
+    "symbol": "OPRAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/opraon_160x160.png"
+  },
+  {
+    "name": "Oracle (Ondo Tokenized)",
+    "address": "GmDADFpfwjfzZq9MfCafMDTS69MgVjtzD7Fd9a4ondo",
+    "symbol": "ORCLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/orclon_160x160.png"
+  },
+  {
+    "name": "Oscar Health (Ondo Tokenized)",
+    "address": "ThwGDsXZ6iKubWuEQjmDxGwF3bUERDGbBXvcbjFondo",
+    "symbol": "OSCRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oscron_160x160.png"
+  },
+  {
+    "name": "Occidental Petroleum (Ondo Tokenized)",
+    "address": "1GNFMryQ6c9ZpMhgNimmsbtgYM21qnBJgRAFoNiondo",
+    "symbol": "OXYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oxyon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Palladium Shares ETF (Ondo Tokenized)",
+    "address": "P7hTXnKk2d2DyqWnefp5BSroE1qjjKpKxg9SxQqondo",
+    "symbol": "PALLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pallon_160x160.png"
+  },
+  {
+    "name": "Palo Alto Networks (Ondo Tokenized)",
+    "address": "M7hVQomhw4Q2D2op3HvBrZjHu9SryjNvD5haEZ1ondo",
+    "symbol": "PANWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/panwon_160x160.png"
+  },
+  {
+    "name": "Global X US Infrastructure Development ETF (Ondo Tokenized)",
+    "address": "DsLQ18ooPjiHYuiuQ5Jz8PNCpVaKe3FhAYpvMxWondo",
+    "symbol": "PAVEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/paveon_160x160.png"
+  },
+  {
+    "name": "Petrobras (Ondo Tokenized)",
+    "address": "GRciFCqJ5y2hbiD6U5mGkohY65BZTXGuGUrCqf7ondo",
+    "symbol": "PBRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pbron_160x160.png"
+  },
+  {
+    "name": "Invesco Optimum Yld Dvsfd Cmd Str No K-1 ETF (Ondo Tokenized)",
+    "address": "M6agiXbNgy8Xon9ngiW4ZDPbMFcNCTMkMMkshZyondo",
+    "symbol": "PDBCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pdbcon_160x160.png"
+  },
+  {
+    "name": "PDD Holdings (Ondo Tokenized)",
+    "address": "PnjETBCLC318DRejo9cMQKAmET9PvW8AEFGWMNtondo",
+    "symbol": "PDDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pddon_160x160.png"
+  },
+  {
+    "name": "PepsiCo (Ondo Tokenized)",
+    "address": "gud6b3fYekjhMG5F818BALwbg2vt4JKoow59Md9ondo",
+    "symbol": "PEPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pepon_160x160.png"
+  },
+  {
+    "name": "Pfizer (Ondo Tokenized)",
+    "address": "Gwh9fPsX1qWATXy63vNaJnAFfwebWQtZaVmPko6ondo",
+    "symbol": "PFEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pfeon_160x160.png"
+  },
+  {
+    "name": "Procter & Gamble (Ondo Tokenized)",
+    "address": "GZ8v4NdSG7CTRZqHMgNsTPRULeVi8CpdWd9wZY8ondo",
+    "symbol": "PGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pgon_160x160.png"
+  },
+  {
+    "name": "Pinterest (Ondo Tokenized)",
+    "address": "sxyg1VTSzy5zYANUK7hntNtmFAWoXGJq95AcHuVondo",
+    "symbol": "PINSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pinson_160x160.png"
+  },
+  {
+    "name": "Palantir Technologies (Ondo Tokenized)",
+    "address": "HfsnTS5qtdStwec9DfBrunRqnAMYMMz1kjv9Hu9ondo",
+    "symbol": "PLTRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pltron_160x160.png"
+  },
+  {
+    "name": "Plug Power (Ondo Tokenized)",
+    "address": "TnfswqdE1jAJ8sfnf5J7kSVLEH1cfpAYZ8MWmKfondo",
+    "symbol": "PLUGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/plugon_160x160.png"
+  },
+  {
+    "name": "abrdn Physical Platinum Shares ETF (Ondo Tokenized)",
+    "address": "DwRtkbsaQMGAS3oMeEGYh6M5vH4X9WECsQgqHjAondo",
+    "symbol": "PPLTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pplton_160x160.png"
+  },
+  {
+    "name": "ProShares Short QQQ (Ondo Tokenized)",
+    "address": "qKtU9A7ij34XmtxaSzYfxCpkgAZzzFsqnUb2kW2ondo",
+    "symbol": "PSQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/psqon_160x160.png"
+  },
+  {
+    "name": "PayPal (Ondo Tokenized)",
+    "address": "hM7B3UQTTR81mS27SxDDPzBbjejmo8fnpFjzgv9ondo",
+    "symbol": "PYPLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pyplon_160x160.png"
+  },
+  {
+    "name": "D-Wave Quantum (Ondo Tokenized)",
+    "address": "hqJXutLF6f7DxStrWCrnZDfXzbNTZmvi3KheVi6ondo",
+    "symbol": "QBTSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qbtson_160x160.png"
+  },
+  {
+    "name": "Qualcomm (Ondo Tokenized)",
+    "address": "hrmX7MV5hifoaBVjnrdpz698yABxrbBNAcWtWo9ondo",
+    "symbol": "QCOMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qcomon_160x160.png"
+  },
+  {
+    "name": "Invesco QQQ (Ondo Tokenized)",
+    "address": "HrYNm6jTQ71LoFphjVKBTdAE4uja7WsmLG8VxB8ondo",
+    "symbol": "QQQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qqqon_160x160.png"
+  },
+  {
+    "name": "Quantum Computing (Ondo Tokenized)",
+    "address": "E4YowrHx5wm4RtSjfuvTqtNH3Wf7NEj5tYZGD9Bondo",
+    "symbol": "QUBTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qubton_160x160.png"
+  },
+  {
+    "name": "Reddit (Ondo Tokenized)",
+    "address": "HXFrTf9v9NdjGUTnx4sojR3Cf92hoBsQFUxKTN7ondo",
+    "symbol": "RDDTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rddton_160x160.png"
+  },
+  {
+    "name": "Redwire (Ondo Tokenized)",
+    "address": "E6KSaqjvqe2HiUpbEweRxLK4RimQddigm95H9Jaondo",
+    "symbol": "RDWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rdwon_160x160.png"
+  },
+  {
+    "name": "Regeneron Pharmaceuticals (Ondo Tokenized)",
+    "address": "E86mX2yb3HLbJM6gRtZQ6dCYmLh6MSDZadu9SCPondo",
+    "symbol": "REGNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/regnon_160x160.png"
+  },
+  {
+    "name": "VanEck Rare Earth and Strategic Metals ETF (Ondo Tokenized)",
+    "address": "tiitb2Z1HtpB2DpVr6V7tdCFS3jmTinLeuGj9EVondo",
+    "symbol": "REMXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/remxon_160x160.png"
+  },
+  {
+    "name": "Rigetti Computing (Ondo Tokenized)",
+    "address": "dwEPNKQab3iwRmjGvZPXhAmws1W5NsQGwuXwi8oondo",
+    "symbol": "RGTIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rgtion_160x160.png"
+  },
+  {
+    "name": "Riot Platforms (Ondo Tokenized)",
+    "address": "i6f3DvZBuLpnGSqS8x6WPeStJ7jNe5KewD6afD5ondo",
+    "symbol": "RIOTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rioton_160x160.png"
+  },
+  {
+    "name": "Rivian Automotive (Ondo Tokenized)",
+    "address": "AXRsYFt7TXNQ3DcY6BkvRgPV6VsYMURyDtaeudjondo",
+    "symbol": "RIVNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rivnon_160x160.png"
+  },
+  {
+    "name": "Rocket Lab (Ondo Tokenized)",
+    "address": "E9VQY3VnrpVSekFByzRmfeK1kxgM3UiKCoVVbdUondo",
+    "symbol": "RKLBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rklbon_160x160.png"
+  },
+  {
+    "name": "RTX (Ondo Tokenized)",
+    "address": "12BvLZtzjdssAycxPeBQUjukhmgQpULAvy6SroYdondo",
+    "symbol": "RTXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rtxon_160x160.png"
+  },
+  {
+    "name": "SharpLink Gaming (Ondo Tokenized)",
+    "address": "iLDu2jjp2i3Uqc2Vm7K7GLiUj3hR4Un49MtD7c4ondo",
+    "symbol": "SBETon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sbeton_160x160.png"
+  },
+  {
+    "name": "Starbucks (Ondo Tokenized)",
+    "address": "iPFqjcZQTNMNXA4kbShbMhfAVD8yr8Uq9UtXMV6ondo",
+    "symbol": "SBUXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sbuxon_160x160.png"
+  },
+  {
+    "name": "Southern Copper (Ondo Tokenized)",
+    "address": "EANjzFjj3nPXHdzN5CE3Z8LLVn69Ce77FE8X4cvondo",
+    "symbol": "SCCOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sccoon_160x160.png"
+  },
+  {
+    "name": "Charles Schwab (Ondo Tokenized)",
+    "address": "cnc6M1zXLdrGR5LAQVcaJDfgezMiVWNtGQsVy1Kondo",
+    "symbol": "SCHWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/schwon_160x160.png"
+  },
+  {
+    "name": "SolarEdge Technologies (Ondo Tokenized)",
+    "address": "EAwP9LGNjTkQ2YeKE6CGKqBYtrJ6APFvRe7KCMmondo",
+    "symbol": "SEDGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sedgon_160x160.png"
+  },
+  {
+    "name": "iShares 0-3 Month Treasury Bond ETF (Ondo Tokenized)",
+    "address": "HjrN6ChZK2QRL6hMXayjGPLFvxhgjwKEy135VRjondo",
+    "symbol": "SGOVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sgovon_160x160.png"
+  },
+  {
+    "name": "Shopify (Ondo Tokenized)",
+    "address": "ivdDracs2s7jCP698dJXKSEQdVrNj9hasJL1Uq1ondo",
+    "symbol": "SHOPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shopon_160x160.png"
+  },
+  {
+    "name": "iShares 1-3 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "EEy57xbaLcUrN1HXj2vz8VWxeWFK1eZQZo4aWbrondo",
+    "symbol": "SHYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shyon_160x160.png"
+  },
+  {
+    "name": "iShares Silver Trust (Ondo Tokenized)",
+    "address": "iy11ytbSGcUnrjE6Lfv78TFqxKyUESfku1FugS9ondo",
+    "symbol": "SLVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/slvon_160x160.png"
+  },
+  {
+    "name": "Super Micro Computer (Ondo Tokenized)",
+    "address": "jLca79XzcewRuBZyaJxVxuKpUHcEix1X4CP1RP9ondo",
+    "symbol": "SMCIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/smcion_160x160.png"
+  },
+  {
+    "name": "Snap (Ondo Tokenized)",
+    "address": "a2cXfonVgQ6cKB4Lm8YZsPry39VZSA562bwmRSiondo",
+    "symbol": "SNAPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/snapon_160x160.png"
+  },
+  {
+    "name": "SanDisk (Ondo Tokenized)",
+    "address": "EJmUVvDqAdfH5zEohkdS4234bi3c6iunqEMobjmondo",
+    "symbol": "SNDKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sndkon_160x160.png"
+  },
+  {
+    "name": "Snowflake (Ondo Tokenized)",
+    "address": "JmFLCBwoNvcXy6B2VqABg6m784ubkXpaEx3p7S5ondo",
+    "symbol": "SNOWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/snowon_160x160.png"
+  },
+  {
+    "name": "SoundHound AI (Ondo Tokenized)",
+    "address": "vE2qArmjto6VfeMngyGAnzp2ipLYeXsxiARDnnXondo",
+    "symbol": "SOUNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sounon_160x160.png"
+  },
+  {
+    "name": "iShares Semiconductor ETF (Ondo Tokenized)",
+    "address": "EN5pHc1LccUSojxb7kkyQi7v7iJN5RpDq6qz3DHondo",
+    "symbol": "SOXXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxxon_160x160.png"
+  },
+  {
+    "name": "S&P Global (Ondo Tokenized)",
+    "address": "JrTYw7A9jihX5TwpRStYviEbsYf2X2VJpZ13719ondo",
+    "symbol": "SPGIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spgion_160x160.png"
+  },
+  {
+    "name": "Spotify (Ondo Tokenized)",
+    "address": "jzCvs2Pk8tDcfsFRqnEMjurgaQW4iQfEkandUR8ondo",
+    "symbol": "SPOTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spoton_160x160.png"
+  },
+  {
+    "name": "SPDR S&P 500 ETF (Ondo Tokenized)",
+    "address": "k18WJUULWheRkSpSquYGdNNmtuE2Vbw1hpuUi92ondo",
+    "symbol": "SPYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/spyon_160x160.png"
+  },
+  {
+    "name": "ProShares UltraPro Short QQQ (Ondo Tokenized)",
+    "address": "D1tu7Fnm3cCpKyyPXrqm5GXShPqMj7a2SEjjq9fondo",
+    "symbol": "SQQQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sqqqon_160x160.png"
+  },
+  {
+    "name": "Seagate (Ondo Tokenized)",
+    "address": "EXtprP1wzrNo2bByrU9JyzqEg2hQMSCVJakeHHYondo",
+    "symbol": "STXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stxon_160x160.png"
+  },
+  {
+    "name": "iShares TIPS Bond ETF (Ondo Tokenized)",
+    "address": "k6BPp2Xmf2TYgrZiUyWfUoZBKeqaDbvPoAVgSx2ondo",
+    "symbol": "TIPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tipon_160x160.png"
+  },
+  {
+    "name": "iShares 20+ Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "KaSLSWByKy6b9FrCYXPEJoHmLpuFZtTCJk1F1Z9ondo",
+    "symbol": "TLTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tlton_160x160.png"
+  },
+  {
+    "name": "Toyota (Ondo Tokenized)",
+    "address": "kbmF7ERJWMaaDswMprrH9gHSLya5D2RMBNgKqg3ondo",
+    "symbol": "TMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tmon_160x160.png"
+  },
+  {
+    "name": "ProShares UltraPro QQQ (Ondo Tokenized)",
+    "address": "14W1itEkV7k1W819mLSknFTaMmkCtPokbF2tRkPUondo",
+    "symbol": "TQQQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tqqqon_160x160.png"
+  },
+  {
+    "name": "Tesla (Ondo Tokenized)",
+    "address": "KeGv7bsfR4MheC1CkmnAVceoApjrkvBhHYjWb67ondo",
+    "symbol": "TSLAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tslaon_160x160.png"
+  },
+  {
+    "name": "Taiwan Semiconductor Manufacturing (Ondo Tokenized)",
+    "address": "keybg184d4vyXeQdFqs4o99YsMg7xBthxTJ6Ky3ondo",
+    "symbol": "TSMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tsmon_160x160.png"
+  },
+  {
+    "name": "Uber (Ondo Tokenized)",
+    "address": "KJNeFW3kk3ycPjXpC6cbuyckjeYHacc2ekhtAi5ondo",
+    "symbol": "UBERon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uberon_160x160.png"
+  },
+  {
+    "name": "Uranium Energy (Ondo Tokenized)",
+    "address": "EYo8D3cLdF1CDeGms5M5VHyU52HJYinkMZ1cqvYondo",
+    "symbol": "UECon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uecon_160x160.png"
+  },
+  {
+    "name": "US Natural Gas Fund (Ondo Tokenized)",
+    "address": "Es2ipHL7qXBcLmZ4N7LP9PHBHaWaTMTAkxDwGGjondo",
+    "symbol": "UNGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ungon_160x160.png"
+  },
+  {
+    "name": "UnitedHealth (Ondo Tokenized)",
+    "address": "kPBGL8vAwKN3UGmr9cjkM2dU79SC3nzTC9yu7F8ondo",
+    "symbol": "UNHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/unhon_160x160.png"
+  },
+  {
+    "name": "Union Pacific Corporation (Ondo Tokenized)",
+    "address": "EvsME8gdnEwPLbTnhrGVDwrY35zBuB8hEGCq59Hondo",
+    "symbol": "UNPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/unpon_160x160.png"
+  },
+  {
+    "name": "Global X Uranium ETF (Ondo Tokenized)",
+    "address": "EvzskrQ3vUUkiMGG1DzfSDyG6H2WCMy3v9G8fzzondo",
+    "symbol": "URAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uraon_160x160.png"
+  },
+  {
+    "name": "United States Oil Fund (Ondo Tokenized)",
+    "address": "rpydAzWdCy85HEmoQkH5PVxYtDYQWjmLxgHHadxondo",
+    "symbol": "USOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usoon_160x160.png"
+  },
+  {
+    "name": "VinFast Auto (Ondo Tokenized)",
+    "address": "F3V1fKLKv7H8aNdt9TC6GQ3X4LayEfGHsPi8Umaondo",
+    "symbol": "VFSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vfson_160x160.png"
+  },
+  {
+    "name": "Vanguard Real Estate ETF (Ondo Tokenized)",
+    "address": "F3dMJ9H137YUNc9cpN3gBWDSq4MSRbTFtojH65Uondo",
+    "symbol": "VNQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vnqon_160x160.png"
+  },
+  {
+    "name": "Visa (Ondo Tokenized)",
+    "address": "kxEW4oJL75K37VeXaZF1ynbHQATQwhECQKN1374ondo",
+    "symbol": "Von",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/von_160x160.png"
+  },
+  {
+    "name": "Vertiv (Ondo Tokenized)",
+    "address": "MkN2TZSYTFBdMRLf9EVcfhstTwnazH8knd9hpepondo",
+    "symbol": "VRTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrton_160x160.png"
+  },
+  {
+    "name": "Vertex Pharmaceuticals (Ondo Tokenized)",
+    "address": "FL7QzUq58pvkDxkftJm7RqRWgqYEFZwXuvAMsUnondo",
+    "symbol": "VRTXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrtxon_160x160.png"
+  },
+  {
+    "name": "Vistra (Ondo Tokenized)",
+    "address": "h6MW8GFpfzxFa1JNn6hZNnBF3t4fj9SHAXKy6LXondo",
+    "symbol": "VSTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vston_160x160.png"
+  },
+  {
+    "name": "Vanguard Total Stock Market ETF (Ondo Tokenized)",
+    "address": "jCCU4GwukjNxAXJowG2S4KCrr5g6YyUB61WHYvGondo",
+    "symbol": "VTIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vtion_160x160.png"
+  },
+  {
+    "name": "Vanguard Value ETF (Ondo Tokenized)",
+    "address": "KuiYLPVq65qixD9TgvxBC576C4gG6vVTCdbh2zFondo",
+    "symbol": "VTVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vtvon_160x160.png"
+  },
+  {
+    "name": "Verizon (Ondo Tokenized)",
+    "address": "igu1coP6n3GPaWmbd8J9Z7UAyLpV254uQFFNfydondo",
+    "symbol": "VZon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vzon_160x160.png"
+  },
+  {
+    "name": "Western Digital (Ondo Tokenized)",
+    "address": "FLqH2jB2DZPJP5nnVFAakRKaNTcDZtq71Pnpp6Aondo",
+    "symbol": "WDCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wdcon_160x160.png"
+  },
+  {
+    "name": "Wells Fargo (Ondo Tokenized)",
+    "address": "L6ZE5qCpVVSqLePz64CrwkgyWoPF9M7tB8BeFH4ondo",
+    "symbol": "WFCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wfcon_160x160.png"
+  },
+  {
+    "name": "Waste Management (Ondo Tokenized)",
+    "address": "FPvKvWzSzDZqgYmSZUetrkpUXSwo2VtpR4BynVYondo",
+    "symbol": "WMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmon_160x160.png"
+  },
+  {
+    "name": "Walmart (Ondo Tokenized)",
+    "address": "LZddqAqKqJW9oMZSjTxCUmbmzBRQtv9gMkD9hZ3ondo",
+    "symbol": "WMTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmton_160x160.png"
+  },
+  {
+    "name": "Terawulf (Ondo Tokenized)",
+    "address": "exYfSJt6Fgfhfnp3bAD4roYy97hLF9npjYaLyEXondo",
+    "symbol": "WULFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wulfon_160x160.png"
+  },
+  {
+    "name": "Exxon Mobil (Ondo Tokenized)",
+    "address": "qCYD74QnXzd9pzv6pGHQKJVwoibL6sNcPQDnpDiondo",
+    "symbol": "XOMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xomon_160x160.png"
+  },
+  {
+    "name": "Block (Ondo Tokenized)",
+    "address": "BWxe2FVciUbwrCUZQPUKiREBh5LmVa5AiUqNLAkondo",
+    "symbol": "XYZon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xyzon_160x160.png"
+  },
+  {
+    "name": "Corning (Ondo Tokenized)",
+    "address": "YQzNQh2YSFQ6nh91E8Ja71U6JuZDLap5jJCsELGondo",
+    "symbol": "GLWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/glwon_160x160.png"
+  },
+  {
+    "name": "Lumentum Holdings (Ondo Tokenized)",
+    "address": "YrquZHx3f6sXsnZZAQiVsyQfvHwLmn2XTkDiZ1uondo",
+    "symbol": "LITEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/liteon_160x160.png"
+  },
+  {
+    "name": "nVent Electric (Ondo Tokenized)",
+    "address": "Z7G1bRFYH47se4g1ppqSgtMzeJs4JjzzFPmt7iAondo",
+    "symbol": "NVTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvton_160x160.png"
+  },
+  {
+    "name": "nLIGHT (Ondo Tokenized)",
+    "address": "Z8aFb6uQJgwFJ4KYKrT8n53aP66xqihodfAu4AKondo",
+    "symbol": "LASRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lasron_160x160.png"
+  },
+  {
+    "name": "FormFactor (Ondo Tokenized)",
+    "address": "ZDnkXeN5awDioQjP691XFLdgZwDAv19g3fCr9KWondo",
+    "symbol": "FORMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/formon_160x160.png"
+  },
+  {
+    "name": "MKS Inc. (Ondo Tokenized)",
+    "address": "ZNkQTVtc4WRMQfVCC23PmwYX41577tPcvs2AiXAondo",
+    "symbol": "MKSIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mksion_160x160.png"
+  },
+  {
+    "name": "Ichor Holdings (Ondo Tokenized)",
+    "address": "ZTABSukbFUFcuCYpMFHxN18aB4kPL2NkpZpgnXPondo",
+    "symbol": "ICHRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ichron_160x160.png"
+  },
+  {
+    "name": "Aehr Test Systems (Ondo Tokenized)",
+    "address": "ZWUSgDGQTQPGJyipzgJKcPhxgZzSBi4q6dqQbgCondo",
+    "symbol": "AEHRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aehron_160x160.png"
+  },
+  {
+    "name": "Camtek (Ondo Tokenized)",
+    "address": "ZcS6FuJ1nAjgwJejUsxkasM6JpEDkdowVyohBCzondo",
+    "symbol": "CAMTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/camton_160x160.png"
+  },
+  {
+    "name": "Wolfspeed (Ondo Tokenized)",
+    "address": "Zfb5PTVfGa8AV6VxrTQJuP8CjMXFPMVkVVNpcAWondo",
+    "symbol": "WOLFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wolfon_160x160.png"
+  },
+  {
+    "name": "Power Integrations (Ondo Tokenized)",
+    "address": "ZifkbVBh94FSETjAfoLw587nxmGsYtXayAAUQgzondo",
+    "symbol": "POWIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/powion_160x160.png"
+  },
+  {
+    "name": "TE Connectivity (Ondo Tokenized)",
+    "address": "ZjYCwYeG85TbV5oXkCkvWQTNPh2PgTQ8X4nxpbyondo",
+    "symbol": "TELon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/telon_160x160.png"
+  },
+  {
+    "name": "Hubbell (Ondo Tokenized)",
+    "address": "ZmiDoowvkpp1Qgx4mmY3qtsHbNV1oE12ApKCbZNondo",
+    "symbol": "HUBBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hubbon_160x160.png"
+  },
+  {
+    "name": "Worthington Steel (Ondo Tokenized)",
+    "address": "ZpJpMhWKCr4m9ZzxApJJwDc5cHiHp2hG1RZdJyvondo",
+    "symbol": "WSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wson_160x160.png"
+  },
+  {
+    "name": "Cloudflare (Ondo Tokenized)",
+    "address": "ZtAY65FCh3YB9H1wkbjRxxY5nXt9VfuTTz3Mzbuondo",
+    "symbol": "NETon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/neton_160x160.png"
+  },
+  {
+    "name": "USA Rare Earth (Ondo Tokenized)",
+    "address": "aA1dRckexLmQyppFoWmjKDFjrNFUsZeGzZ7L5xpondo",
+    "symbol": "USARon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/usaron_160x160.png"
+  },
+  {
+    "name": "Himax Technologies (Ondo Tokenized)",
+    "address": "aCx5G8ewGTSzozEn8KmSsr9cvfyFWzGnr22GjFXondo",
+    "symbol": "HIMXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/himxon_160x160.png"
+  },
+  {
+    "name": "MaxLinear (Ondo Tokenized)",
+    "address": "aGn43ed4kjATwbVqsAuwAT24XcG9xABCcyQsFpqondo",
+    "symbol": "MXLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mxlon_160x160.png"
+  },
+  {
+    "name": "Onto Innovation (Ondo Tokenized)",
+    "address": "aHFrgfBHMGEScG8j64cN324jeoQ4EVXLmiHxtuPondo",
+    "symbol": "ONTOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ontoon_160x160.png"
+  },
+  {
+    "name": "Teradyne (Ondo Tokenized)",
+    "address": "ahvtJqt6pkzjnYTMaCKrvjPQszSKyWraiXKvuWKondo",
+    "symbol": "TERon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/teron_160x160.png"
+  },
+  {
+    "name": "Nokia (Ondo Tokenized)",
+    "address": "amE2ANm5dyG6RTkJHdtzvWcuR8ChBZCEm5Jiqwdondo",
+    "symbol": "NOKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nokon_160x160.png"
+  },
+  {
+    "name": "Planet Labs (Ondo Tokenized)",
+    "address": "aq2zXUHqx7Zk6HSJH2GYsNajQJZj9f3dV7gAzfuondo",
+    "symbol": "PLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/plon_160x160.png"
+  },
+  {
+    "name": "Enbridge (Ondo Tokenized)",
+    "address": "aqEnHXRnXEQwDXEiFSEU4xHziw3Fco4b5JPkTtnondo",
+    "symbol": "ENBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/enbon_160x160.png"
+  },
+  {
+    "name": "MYR Group (Ondo Tokenized)",
+    "address": "auLvQAhUzPuy2SQBSq2T6AofPGNkR4nZ83P8pjuondo",
+    "symbol": "MYRGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/myrgon_160x160.png"
+  },
+  {
+    "name": "Entegris (Ondo Tokenized)",
+    "address": "awCwGaVNbYJH2SyQJzgE3mB54gxa6SQEZSKZaHQondo",
+    "symbol": "ENTGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/entgon_160x160.png"
+  },
+  {
+    "name": "Hewlett Packard Enterprise (Ondo Tokenized)",
+    "address": "axbgKgUMscTJ34DjA69kBJuf6UYq4Pzb8B8numYondo",
+    "symbol": "HPEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hpeon_160x160.png"
+  },
+  {
+    "name": "Alpha and Omega Semiconductor (Ondo Tokenized)",
+    "address": "b98FynyBEkdhP4Y3QUvKG36nms4oMsxEZUrCBMvondo",
+    "symbol": "AOSLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aoslon_160x160.png"
+  },
+  {
+    "name": "NuScale Power (Ondo Tokenized)",
+    "address": "bGy2covWNf5qyzoNdV1pWXuLmFi6Dq927o7JXzWondo",
+    "symbol": "SMRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/smron_160x160.png"
+  },
+  {
+    "name": "STMicroelectronics (Ondo Tokenized)",
+    "address": "bM2VSRfbYPt29YRD9F2wTCSCSQaHtNCuz1znNDCondo",
+    "symbol": "STMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stmon_160x160.png"
+  },
+  {
+    "name": "EQT (Ondo Tokenized)",
+    "address": "bWrYATfytuRwGoDbpxy16aQbMbCZDv8DURuLCAhondo",
+    "symbol": "EQTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/eqton_160x160.png"
+  },
+  {
+    "name": "SAP (Ondo Tokenized)",
+    "address": "bjbrNi96mXAzgvxSuGJ2SRJ5U4N8agbG7wUAKAjondo",
+    "symbol": "SAPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sapon_160x160.png"
+  },
+  {
+    "name": "Williams (Ondo Tokenized)",
+    "address": "bvjmEwQBqbMr6rnx5a74boBz6nmA1DNThujPnNAondo",
+    "symbol": "WMBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wmbon_160x160.png"
+  },
+  {
+    "name": "Fluence Energy (Ondo Tokenized)",
+    "address": "bzoe1epsQLx65zmez4pWfBumYzpaFwRTvnmCjZVondo",
+    "symbol": "FLNCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flncon_160x160.png"
+  },
+  {
+    "name": "Cerebras Systems (Ondo Tokenized)",
+    "address": "c7KEKjzaTQYpTrHM2db8yq3bikPpcXrHgBV8Qcgondo",
+    "symbol": "CBRSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cbrson_160x160.png"
+  },
+  {
+    "name": "Dell Technologies (Ondo Tokenized)",
+    "address": "cFDP5SsUBeKrV1RkKHdaofHBSfRW8cBd7DiaPTSLAon",
+    "symbol": "DELLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dellon_160x160.png"
+  },
+  {
+    "name": "Tower Semiconductor (Ondo Tokenized)",
+    "address": "cRx9VtwwPTZbVk1DjbMyKzrMWn7nJA22UpMyzFYondo",
+    "symbol": "TSEMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tsemon_160x160.png"
+  },
+  {
+    "name": "Ciena (Ondo Tokenized)",
+    "address": "cY3kDrNWP6DUZcWSQmA6Y4Nf7q5qS5kZ8zF9iLnondo",
+    "symbol": "CIENon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cienon_160x160.png"
+  },
+  {
+    "name": "Fabrinet (Ondo Tokenized)",
+    "address": "cfxyRHXjqoKN6hF3oEGu1bpEEFGcEiVXoNG4UUCondo",
+    "symbol": "FNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fnon_160x160.png"
+  },
+  {
+    "name": "Arqit Quantum (Ondo Tokenized)",
+    "address": "crakmaGKTuVRYqSBsFsuqio5CmpEQnpibDrVLbDondo",
+    "symbol": "ARQQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/arqqon_160x160.png"
+  },
+  {
+    "name": "Astera Labs (Ondo Tokenized)",
+    "address": "cskxd6aqyqJMYgLZmFYfYecWkjasRJDEtm1QVxsondo",
+    "symbol": "ALABon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/alabon_160x160.png"
+  },
+  {
+    "name": "Credo Technology Group Holding (Ondo Tokenized)",
+    "address": "d4Rc6KvP3nQT8zC86Z31zM1DJCSfUD6y424cKnZondo",
+    "symbol": "CRDOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/crdoon_160x160.png"
+  },
+  {
+    "name": "MACOM Technology Solutions Holdings (Ondo Tokenized)",
+    "address": "dAc8yWUrVra9v2PGsn3LT18oybsM62ysQ4ikWcpondo",
+    "symbol": "MTSIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mtsion_160x160.png"
+  },
+  {
+    "name": "Lightwave Logic (Ondo Tokenized)",
+    "address": "dKGNHXGsZL4GZ4UBTCjpPbaMerqe1EdZ7aFdCxHondo",
+    "symbol": "LWLGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lwlgon_160x160.png"
+  },
+  {
+    "name": "Vishay Precision Group (Ondo Tokenized)",
+    "address": "dYF78b65HS62V3pku2uYFyektYzAhx9YACv4hWfondo",
+    "symbol": "VPGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vpgon_160x160.png"
+  },
+  {
+    "name": "LightPath Technologies (Ondo Tokenized)",
+    "address": "dhEXYTmQKbYBH3wbWTMqeZZpADSRprM4jiGYbUMondo",
+    "symbol": "LPTHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lpthon_160x160.png"
+  },
+  {
+    "name": "Rockwell Automation (Ondo Tokenized)",
+    "address": "e83tWWrVsVk1hRGNz5BCwNr9TMBNWixmoUhWgYcondo",
+    "symbol": "ROKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rokon_160x160.png"
+  },
+  {
+    "name": "Mobileye Global (Ondo Tokenized)",
+    "address": "eCSPcjdpdKL1546PU3RM6BXkebuKn8iH4iuMcTBondo",
+    "symbol": "MBLYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/mblyon_160x160.png"
+  },
+  {
+    "name": "Aurora Innovation (Ondo Tokenized)",
+    "address": "eGbh3V9R5ujWYwKJZAyM4Eg3sfzLhwKyr4bGbTsondo",
+    "symbol": "AURon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/auron_160x160.png"
+  },
+  {
+    "name": "Celestica (Ondo Tokenized)",
+    "address": "eL1buL9zFxFhfRbjMfyPu2q9HSAJkUUnHVUgkPdondo",
+    "symbol": "CLSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/clson_160x160.png"
+  },
+  {
+    "name": "Kopin (Ondo Tokenized)",
+    "address": "eSu547weHVErV8nax42PyJzPT8JodhBfXLDp5vyondo",
+    "symbol": "KOPNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/kopnon_160x160.png"
+  },
+  {
+    "name": "Generac Holdings (Ondo Tokenized)",
+    "address": "eqzwohR9oCR6sravF4y5HyUwyvCDbnfSYqiiFrXondo",
+    "symbol": "GNRCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gnrcon_160x160.png"
+  },
+  {
+    "name": "Trane Technologies (Ondo Tokenized)",
+    "address": "erp2t2My8UoFgyRt39EmnnSiDUwUM5aNKw5piBKondo",
+    "symbol": "TTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tton_160x160.png"
+  },
+  {
+    "name": "Fundrise Innovation Fund (Ondo Tokenized)",
+    "address": "esgtAV7yKf7Ei3Q92VmXcEGkoqY2UqCHzZvCWhgondo",
+    "symbol": "VCXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vcxon_160x160.png"
+  },
+  {
+    "name": "GlobalFoundries (Ondo Tokenized)",
+    "address": "etnBzce6pkJq67QUv78PefkVyCEaA6YBE4hvx1Gondo",
+    "symbol": "GFSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gfson_160x160.png"
+  },
+  {
+    "name": "Energy Fuels (Ondo Tokenized)",
+    "address": "ey16y4Bk92zmPSvbRznuv3RioAXbVreBkQxrKGDondo",
+    "symbol": "UUUUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uuuuon_160x160.png"
+  },
+  {
+    "name": "Quanta Services (Ondo Tokenized)",
+    "address": "f1yQz2fo7S24NqrsfaWDkmQ8xoa8yU72c9rEEBdondo",
+    "symbol": "PWRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/pwron_160x160.png"
+  },
+  {
+    "name": "Core Scientific (Ondo Tokenized)",
+    "address": "f4ucqqnktrkdDAnwqcAAiA9Lggz6NAHJ3zFwipnondo",
+    "symbol": "CORZon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/corzon_160x160.png"
+  },
+  {
+    "name": "Hut 8 (Ondo Tokenized)",
+    "address": "f7iz4BQsnjw95EUyFiBKAnKgo7oBrycfzQdtmDwondo",
+    "symbol": "HUTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/huton_160x160.png"
+  },
+  {
+    "name": "Vicor (Ondo Tokenized)",
+    "address": "f9nfUo4SdhCGfHmm81m3ArgDsatwo2jLjEcgCcYondo",
+    "symbol": "VICRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vicron_160x160.png"
+  },
+  {
+    "name": "Amphenol (Ondo Tokenized)",
+    "address": "fFTZ9Jckm2X811mdqRBS4ckMz5bRAJVjH4Jwofwondo",
+    "symbol": "APHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aphon_160x160.png"
+  },
+  {
+    "name": "Powell Industries (Ondo Tokenized)",
+    "address": "fRFzaZfGSXPf2r4oBgBBXpisRovMaJZjv1aCQBsondo",
+    "symbol": "POWLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/powlon_160x160.png"
+  },
+  {
+    "name": "Cleveland-Cliffs (Ondo Tokenized)",
+    "address": "fTuoE9pWbVK7EUpUEENBn8Vu226T7kF3YJBTRLPondo",
+    "symbol": "CLFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/clfon_160x160.png"
+  },
+  {
+    "name": "Cameco (Ondo Tokenized)",
+    "address": "fVPj4hHHVEeUrzVnad5fvxFEPGAXD5X6wkw1Xjdondo",
+    "symbol": "CCJon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ccjon_160x160.png"
+  },
+  {
+    "name": "Navitas Semiconductor (Ondo Tokenized)",
+    "address": "fXXYmrdSAwVmtNo1ZwrkxVep7BxTsusGzmUZJSPondo",
+    "symbol": "NVTSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvtson_160x160.png"
+  },
+  {
+    "name": "iShares Floating Rate Loan Active ETF (Ondo Tokenized)",
+    "address": "fcfpT8y5fpEBJjqmjKLpscZYzVjxR95ErJsb31jondo",
+    "symbol": "BRLNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brlnon_160x160.png"
+  },
+  {
+    "name": "iShares Investment Grade Systematic Bond ETF (Ondo Tokenized)",
+    "address": "feZXF2iFspS6QKE4LSXeSESRXgrtvzbE3dZSyydondo",
+    "symbol": "IGEBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/igebon_160x160.png"
+  },
+  {
+    "name": "iShares Aaa - A Rated Corporate Bond ETF (Ondo Tokenized)",
+    "address": "fkznXN9GALK7f9zVr2RwRHWCPhwoima4zB3JbbNondo",
+    "symbol": "QLTAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qltaon_160x160.png"
+  },
+  {
+    "name": "iShares High Yield Active ETF (Ondo Tokenized)",
+    "address": "fznj92AnTcQ6mAFvt68JgLJS5pHag5uPmJ7LmSLondo",
+    "symbol": "BRHYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brhyon_160x160.png"
+  },
+  {
+    "name": "iShares Large Cap Core Active ETF (Ondo Tokenized)",
+    "address": "g3jQMP79SxnH1KisVw3C4SBpa8gSbPAocNJruJFondo",
+    "symbol": "BLCRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/blcron_160x160.png"
+  },
+  {
+    "name": "iShares US Industry Rotation Active ETF (Ondo Tokenized)",
+    "address": "g4kT9HEg7rN4e5ZaEGHmzpkdM8qMbsZSHJojKeCondo",
+    "symbol": "INROon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inroon_160x160.png"
+  },
+  {
+    "name": "iShares US Equity Factor Rotation Active ETF (Ondo Tokenized)",
+    "address": "g7vMfs5FrR8JjieeGC3c9sJaYPp4G3jGPfF4tkyondo",
+    "symbol": "DYNFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dynfon_160x160.png"
+  },
+  {
+    "name": "iShares A.I. Innovation and Tech Active ETF (Ondo Tokenized)",
+    "address": "gKkrSgVjRjdQX4LFErBka1izQhoW2VHXFcCS5Vbondo",
+    "symbol": "BAIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/baion_160x160.png"
+  },
+  {
+    "name": "iShares International Country Rotation Active ETF (Ondo Tokenized)",
+    "address": "gNhrgh21pQozQoc7YtvhdKF7eJnSKwWa9dzHnaxondo",
+    "symbol": "COROon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/coroon_160x160.png"
+  },
+  {
+    "name": "iShares Total Return Active ETF (Ondo Tokenized)",
+    "address": "gPwmyo4BM4qgYYCTVgA4eJmzsnYNVMUJYBecYkCondo",
+    "symbol": "BRTRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/brtron_160x160.png"
+  },
+  {
+    "name": "iShares Systematic Alternatives Active ETF (Ondo Tokenized)",
+    "address": "gfKuBLive7Q35MYgxPgNx7qx524zQJ9RiDZJFZoondo",
+    "symbol": "IALTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ialton_160x160.png"
+  },
+  {
+    "name": "Oceaneering International (Ondo Tokenized)",
+    "address": "gfTDvjLp8K5gNDFaLMvoTZWJJY6PmVQfdPaUU7eondo",
+    "symbol": "OIIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/oiion_160x160.png"
+  },
+  {
+    "name": "Iridium Communications (Ondo Tokenized)",
+    "address": "go6DXMdM5zHTC9G16BwAYA8rKwGRhy9M5uudNdBondo",
+    "symbol": "IRDMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/irdmon_160x160.png"
+  },
+  {
+    "name": "Leonardo DRS (Ondo Tokenized)",
+    "address": "gtKc3PtKfUH7vbvYLJ1HCRXCpQK1Wpgevn8e6gUondo",
+    "symbol": "DRSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/drson_160x160.png"
+  },
+  {
+    "name": "Huntington Ingalls Industries (Ondo Tokenized)",
+    "address": "h73FNVBDq95fqGBy5eunHm2FVfu2jWZNkeXHDieondo",
+    "symbol": "HIIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hiion_160x160.png"
+  },
+  {
+    "name": "General Dynamics (Ondo Tokenized)",
+    "address": "hESwwvKsJH4p7Xib5rrM921Ng19cwcQGtxyrgSJondo",
+    "symbol": "GDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/gdon_160x160.png"
+  },
+  {
+    "name": "Vanguard Energy ETF (Ondo Tokenized)",
+    "address": "hKVpWfYwP1VJ9BcBTPRcovcSpEkvnaN8eXwFoCMondo",
+    "symbol": "VDEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vdeon_160x160.png"
+  },
+  {
+    "name": "US Copper Index Fund (Ondo Tokenized)",
+    "address": "hpkpc1Xenv5oEpVefk3woWjZa9rxaJxaEaVVA4Fondo",
+    "symbol": "CPERon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cperon_160x160.png"
+  },
+  {
+    "name": "First Majestic Silver (Ondo Tokenized)",
+    "address": "hrZ5vs6c6v1iWyvEXjGSHs3sQuuj58VzXikNyRWondo",
+    "symbol": "AGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/agon_160x160.png"
+  },
+  {
+    "name": "SLB (Ondo Tokenized)",
+    "address": "i7ZS13SF6BCKbzvLujp2UqLNMgM1XVnZ7A7wC6tondo",
+    "symbol": "SLBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/slbon_160x160.png"
+  },
+  {
+    "name": "Halliburton (Ondo Tokenized)",
+    "address": "iFcwEB2LfeYLWKgZ2vogEzC5dP7s7xbhVX81XFwondo",
+    "symbol": "HALon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/halon_160x160.png"
+  },
+  {
+    "name": "Skyworks Solutions (Ondo Tokenized)",
+    "address": "iJtKb1CWnWdgJhs7HgSZvLmSJABGGMc97QeuG7tondo",
+    "symbol": "SWKSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/swkson_160x160.png"
+  },
+  {
+    "name": "United Microelectronics (Ondo Tokenized)",
+    "address": "ieocA48cBX3oiVECgosMGxG649wnf7R8EkVrA5fondo",
+    "symbol": "UMCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/umcon_160x160.png"
+  },
+  {
+    "name": "Jabil (Ondo Tokenized)",
+    "address": "igWFQo1W64cQN6QUWYRXhM1UvpPuYTYtLELbDYqqqon",
+    "symbol": "JBLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/jblon_160x160.png"
+  },
+  {
+    "name": "Flex (Ondo Tokenized)",
+    "address": "iicfp8Efr4WfGAP9gXmYzdxmNFi1LV3iVudAmCnondo",
+    "symbol": "FLEXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/flexon_160x160.png"
+  },
+  {
+    "name": "Invesco PHLX Semiconductor ETF (Ondo Tokenized)",
+    "address": "io3eLhnjT1a94JpzAUMWKqwMYHZRwvtGXjkkXsPondo",
+    "symbol": "SOXQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxqon_160x160.png"
+  },
+  {
+    "name": "Direxion Daily Semi Bull 3X ETF (Ondo Tokenized)",
+    "address": "isRSJECP9yFPv9YejzGUdjzAGHbF2x5DpVeDqAiondo",
+    "symbol": "SOXLon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/soxlon_160x160.png"
+  },
+  {
+    "name": "Ultra Clean Holdings (Ondo Tokenized)",
+    "address": "jCPs1JpVKAwevND3jzeDGAUBBFkJ5TUtiu2SxLbondo",
+    "symbol": "UCTTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uctton_160x160.png"
+  },
+  {
+    "name": "Axcelis Technologies (Ondo Tokenized)",
+    "address": "jDoTgDRKSgVzkKdkaHZL3DiVmDM4YtYWwRG6Tgfondo",
+    "symbol": "ACLSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aclson_160x160.png"
+  },
+  {
+    "name": "Cohu (Ondo Tokenized)",
+    "address": "jYMxpcgARQCdvQ15H1vvRCnBUbUEEQgSnS6SsfTondo",
+    "symbol": "COHUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cohuon_160x160.png"
+  },
+  {
+    "name": "Keysight Technologies (Ondo Tokenized)",
+    "address": "jYcn4hHgyq1fS46YgecQY9N1gLU3sAxKA3DZVAPondo",
+    "symbol": "KEYSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/keyson_160x160.png"
+  },
+  {
+    "name": "iShares Expanded Tech-Software ETF (Ondo Tokenized)",
+    "address": "jYxKRFuXr6PEkzPpf1wWF7DhLL4gxGJ95Pv2NGrondo",
+    "symbol": "IGVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/igvon_160x160.png"
+  },
+  {
+    "name": "VeriSign (Ondo Tokenized)",
+    "address": "ja4bMvHL3Hw9Ey33VGWyDeXvrHvQWyBnK4GSmCUondo",
+    "symbol": "VRSNon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vrsnon_160x160.png"
+  },
+  {
+    "name": "Vishay Intertechnology (Ondo Tokenized)",
+    "address": "jbzBdFNddeEiJXGcVH4DE2qUyYfTtyY2vaHJDEZondo",
+    "symbol": "VSHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/vshon_160x160.png"
+  },
+  {
+    "name": "Methode Electronics (Ondo Tokenized)",
+    "address": "jiwgLgWJ8f6aEsM6hcSCrXLNnGpYfjmCVbqqAcwondo",
+    "symbol": "MEIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/meion_160x160.png"
+  },
+  {
+    "name": "Rambus (Ondo Tokenized)",
+    "address": "jjnSEAsi8UbCez7x9XCbWntLWRHBdc2tWSdC3uoondo",
+    "symbol": "RMBSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rmbson_160x160.png"
+  },
+  {
+    "name": "Arteris (Ondo Tokenized)",
+    "address": "jmnrdSzu293vKTWyEx3A2ZRVxxytJKW1wD3CLzkondo",
+    "symbol": "AIPon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aipon_160x160.png"
+  },
+  {
+    "name": "Extreme Networks (Ondo Tokenized)",
+    "address": "js1cCZRNx8ircYiQJuhBNMnsA9owr6ZLYx6z2uNondo",
+    "symbol": "EXTRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/extron_160x160.png"
+  },
+  {
+    "name": "WhiteFiber (Ondo Tokenized)",
+    "address": "jtnRMv1U3bJHQCsi47E6Lf8Nzkaqsisef7SkHBgondo",
+    "symbol": "WYFIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wyfion_160x160.png"
+  },
+  {
+    "name": "Digi Power X (Ondo Tokenized)",
+    "address": "jwCKwGoJfx1p4K5XCwqPrq1xyJU1g26Tmf6UcDcondo",
+    "symbol": "DGXXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dgxxon_160x160.png"
+  },
+  {
+    "name": "Bitdeer Technologies (Ondo Tokenized)",
+    "address": "kBUAHgGHFthfnwarWxqYxHqVDnqqieJkXb6kvroondo",
+    "symbol": "BTDRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/btdron_160x160.png"
+  },
+  {
+    "name": "Keel Infrastructure (Ondo Tokenized)",
+    "address": "kSbeWEe64qpoVb1ZSVxgRnekZ1PwGNJkLyL5gJWondo",
+    "symbol": "KEELon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/keelon_160x160.png"
+  },
+  {
+    "name": "HIVE Digital Technologies (Ondo Tokenized)",
+    "address": "kTMQKHhnWPTvZsfiZfcdeHdG6dMgZV27wXSiC3Yondo",
+    "symbol": "HIVEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hiveon_160x160.png"
+  },
+  {
+    "name": "TTM Technologies (Ondo Tokenized)",
+    "address": "kWmjV2XdK5tbV6kZrM8grS6EGFmuH5i5HFW3YyLondo",
+    "symbol": "TTMIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ttmion_160x160.png"
+  },
+  {
+    "name": "Primoris Services (Ondo Tokenized)",
+    "address": "kcc5QzXDCQ61qQ5Nbpi2RppnRSzhG1XQNXkjXwoondo",
+    "symbol": "PRIMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/primon_160x160.png"
+  },
+  {
+    "name": "Lincoln Electric (Ondo Tokenized)",
+    "address": "kmppRwWb2odH6D4JWj8Lq9WshMyyUeCYssWQFhiondo",
+    "symbol": "LECOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lecoon_160x160.png"
+  },
+  {
+    "name": "Forgent Power Solutions (Ondo Tokenized)",
+    "address": "m3XghfWMqmVE81LKLVxd1FVCKjqYAUxH8bMHGhzondo",
+    "symbol": "FPSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/fpson_160x160.png"
+  },
+  {
+    "name": "WESCO International (Ondo Tokenized)",
+    "address": "m3m2HAANsAf2Y3BkdBixDgtrrFHnZDp4NqVh9obondo",
+    "symbol": "WCCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wccon_160x160.png"
+  },
+  {
+    "name": "Breakwave Tanker Shipping ETF (Ondo Tokenized)",
+    "address": "m7mWfvhyPikY3esNwTk8U1JRbcBijmzHgqiqx3xondo",
+    "symbol": "BWETon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bweton_160x160.png"
+  },
+  {
+    "name": "Scorpio Tankers (Ondo Tokenized)",
+    "address": "mFyszXnJf8BFR8H4o33pCZS1T36BH9LjtG3gTpdondo",
+    "symbol": "STNGon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stngon_160x160.png"
+  },
+  {
+    "name": "Teekay Tankers (Ondo Tokenized)",
+    "address": "mPAqB3y5N7fWmEh1BoVtrLhZKBkQe7LjBCrYUNbondo",
+    "symbol": "TNKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tnkon_160x160.png"
+  },
+  {
+    "name": "International Seaways (Ondo Tokenized)",
+    "address": "mV5mof9x8nDirrHwT7g16MarvHbnRvz2zN2S4Cspyon",
+    "symbol": "INSWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inswon_160x160.png"
+  },
+  {
+    "name": "Tsakos Energy Navigation (Ondo Tokenized)",
+    "address": "micfqeFfvD9iDKKzuqRHXerFxG8K5VfY8CgrcQoondo",
+    "symbol": "TENon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/tenon_160x160.png"
+  },
+  {
+    "name": "Nordic American Tankers (Ondo Tokenized)",
+    "address": "mmy8WbFRNrjoDsPGqpYmzQAVu7PfGhMCdSRLxZLondo",
+    "symbol": "NATon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/naton_160x160.png"
+  },
+  {
+    "name": "Okeanis Eco Tankers (Ondo Tokenized)",
+    "address": "mnYetf4bWKX8HihNk1XLNYj8BPPy9PdkDFPV97Zondo",
+    "symbol": "ECOon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ecoon_160x160.png"
+  },
+  {
+    "name": "Westlake (Ondo Tokenized)",
+    "address": "mrNSd1y72F7Dx2Uip4vidtsJKKd8iJatTKGX6Pvondo",
+    "symbol": "WLKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wlkon_160x160.png"
+  },
+  {
+    "name": "Nucor (Ondo Tokenized)",
+    "address": "mvAUPvwKPW4rbbTXkqCvcZEG45XCeRHSVcLVym8ondo",
+    "symbol": "NUEon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nueon_160x160.png"
+  },
+  {
+    "name": "Steel Dynamics (Ondo Tokenized)",
+    "address": "n7DwzSkv1SBkcA9qj8LU9sZ9sRn72Z6spU2w2b9ondo",
+    "symbol": "STLDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/stldon_160x160.png"
+  },
+  {
+    "name": "Lattice Semiconductor (Ondo Tokenized)",
+    "address": "nDetEKBEk9chztCXSYNrU5F63s2RCEQCxT7BhxDondo",
+    "symbol": "LSCCon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lsccon_160x160.png"
+  },
+  {
+    "name": "CEVA (Ondo Tokenized)",
+    "address": "nLTgFdT7x37oXMbZoZxbQ1787qSPVRLXo7JPRkLondo",
+    "symbol": "CEVAon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/cevaon_160x160.png"
+  },
+  {
+    "name": "Emerson Electric (Ondo Tokenized)",
+    "address": "nNyVbs9Qty6wU2YcP5KFh4SUxNWTdPtL2W1bTMrondo",
+    "symbol": "EMRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/emron_160x160.png"
+  },
+  {
+    "name": "Symbotic (Ondo Tokenized)",
+    "address": "nP42LxpSZkUfnBUxiFsHxL5GKYWRZ1VxqGkMTNwondo",
+    "symbol": "SYMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/symon_160x160.png"
+  },
+  {
+    "name": "TaskUs (Ondo Tokenized)",
+    "address": "nQysX1ZsRJ8yTJg8smZTZ91rWcVBabDRqdUEKZHondo",
+    "symbol": "TASKon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/taskon_160x160.png"
+  },
+  {
+    "name": "Innodata (Ondo Tokenized)",
+    "address": "nTUjRdtzGCy8FXHK8w1n11pHABX6Dc7L7WSpzdBondo",
+    "symbol": "INODon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/inodon_160x160.png"
+  },
+  {
+    "name": "Hesai Group (Ondo Tokenized)",
+    "address": "nagL8iWMNLZVuKFk3bUGDaHyT5ZY4bNfUzsdtGHondo",
+    "symbol": "HSAIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hsaion_160x160.png"
+  },
+  {
+    "name": "United States Antimony (Ondo Tokenized)",
+    "address": "nbwNoPaFYNY2c3u4iK6U59ySC2ehFrpjdpfbyLDondo",
+    "symbol": "UAMYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/uamyon_160x160.png"
+  },
+  {
+    "name": "REalloys (Ondo Tokenized)",
+    "address": "ndHvUEgrvZquSR6wZv2cG1AiBr7e7HGuWvfPULcondo",
+    "symbol": "ALOYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aloyon_160x160.png"
+  },
+  {
+    "name": "ACM Research (Ondo Tokenized)",
+    "address": "nkbH2doD7nU4CkKVwzmd6UV4d2AaGy24NHzsh6tondo",
+    "symbol": "ACMRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/acmron_160x160.png"
+  },
+  {
+    "name": "Nova (Ondo Tokenized)",
+    "address": "nupQ2BuCfoVeCHVLRDhTjLJanaf5cxZ81KVFqs6ondo",
+    "symbol": "NVMIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nvmion_160x160.png"
+  },
+  {
+    "name": "Amkor Technology (Ondo Tokenized)",
+    "address": "nvvoP8gFyY2aZp6Cxu9Qq4MQqGrMebjtCxWrYfbondo",
+    "symbol": "AMKRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/amkron_160x160.png"
+  },
+  {
+    "name": "Harmonic (Ondo Tokenized)",
+    "address": "o3pnLke4uti6hY3LTfb2wVBpHeWG7znjJHj6VXtondo",
+    "symbol": "HLITon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hliton_160x160.png"
+  },
+  {
+    "name": "Roundhill Memory ETF (Ondo Tokenized)",
+    "address": "oXeD5ZesXfJQ3mxtuZdMaccUsWrE8r1SnpYRP2Bondo",
+    "symbol": "DRAMon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dramon_160x160.png"
+  },
+  {
+    "name": "Global X MSCI Argentina ETF (Ondo Tokenized)",
+    "address": "rki25TZmDh94spjeoyyGWjkVEYSzcVvaAbddXGuondo",
+    "symbol": "ARGTon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/argton_160x160.png"
+  },
+  {
+    "name": "Global X Defense Tech ETF (Ondo Tokenized)",
+    "address": "siVse6kjZb9ihaXHaqoG3mhHyTPEnNCkvSDTheoondo",
+    "symbol": "SHLDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/shldon_160x160.png"
+  },
+  {
+    "name": "Global X Robotics & Artificial Intelligence ETF (Ondo Tokenized)",
+    "address": "soLM6jRVdG1PdurSAQDz5qRtwWxXPM6EBvwrkBjondo",
+    "symbol": "BOTZon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/botzon_160x160.png"
+  },
+  {
+    "name": "Global X Lithium & Battery Tech ETF (Ondo Tokenized)",
+    "address": "syb82jXkHWbcWgxoRqrvAcoCdsAb3y1fnCYo561ondo",
+    "symbol": "LITon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/liton_160x160.png"
+  },
+  {
+    "name": "Global X Data Center & Digital Infrastructure ETF (Ondo Tokenized)",
+    "address": "t29YBAB7g6xzgRJkzmc5NkQ7YRjE3NF8mhsLgppondo",
+    "symbol": "DTCRon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/dtcron_160x160.png"
+  },
+  {
+    "name": "Global X Space Tech ETF (Ondo Tokenized)",
+    "address": "t5XWftMCacS1p3xrg14ARaxgEvEM5R241kxHGqrondo",
+    "symbol": "ORBXon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/orbxon_160x160.png"
+  },
+  {
+    "name": "iShares Euro High Yield Corporate Bond USD Hedged ETF (Ondo Tokenized)",
+    "address": "teUYhoQUgqsFp9ZwYBUHfuUHdVvbNx9N8spESGqondo",
+    "symbol": "EUHYon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/euhyon_160x160.png"
+  },
+  {
+    "name": "iShares J.P. Morgan EM Local Currency Bond ETF (Ondo Tokenized)",
+    "address": "teZfcA6zpP476eKzED1daqBWDtuwbk9e2Ejk2cpondo",
+    "symbol": "LEMBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/lembon_160x160.png"
+  },
+  {
+    "name": "iShares Defense Industrials Active ETF (Ondo Tokenized)",
+    "address": "th3tot4SRq6jgEyJ568NEh42MM82RSJ3NkiWeNzondo",
+    "symbol": "IDEFon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/idefon_160x160.png"
+  },
+  {
+    "name": "iShares Global Government Bond USD Hedged Active ETF (Ondo Tokenized)",
+    "address": "tzuC3sZnHg7spuAFhdCqivx9qtJg15qUBUpCJx1ondo",
+    "symbol": "GGOVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ggovon_160x160.png"
+  },
+  {
+    "name": "Global X NASDAQ 100 Covered Call ETF (Ondo Tokenized)",
+    "address": "ueEYw3Djy9GVu9mrP6jum8qNpxshgcy7gMfmntWondo",
+    "symbol": "QYLDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/qyldon_160x160.png"
+  },
+  {
+    "name": "Global X Silver Miners ETF (Ondo Tokenized)",
+    "address": "uiSLmtLdqxtbQq5gkwYBvBrZpnSNXZn8h6sjLsDondo",
+    "symbol": "SILon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/silon_160x160.png"
+  },
+  {
+    "name": "Global X Artificial Intelligence & Technology ETF (Ondo Tokenized)",
+    "address": "uwh6Z6c2F8WZfUSK1A8VBfA9AwJKN5T2bvQwVFLondo",
+    "symbol": "AIQon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aiqon_160x160.png"
+  },
+  {
+    "name": "Global X Blockchain ETF (Ondo Tokenized)",
+    "address": "uyWDgDZqL6x2V86i7vwJTKPuyg2u79UYaBe5yt7ondo",
+    "symbol": "BKCHon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bkchon_160x160.png"
+  },
+  {
+    "name": "iShares MSCI EAFE Value ETF (Ondo Tokenized)",
+    "address": "uzQx2MnWr7drR5gdNXssJrFKQkLFSdw4EpfaQ5Nondo",
+    "symbol": "EFVon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/efvon_160x160.png"
+  },
+  {
+    "name": "iShares S&P Small-Cap 600 Value ETF (Ondo Tokenized)",
+    "address": "v34vtrbcjDswpFDixpVFThmUWeM1RTZwtWcp5FBondo",
+    "symbol": "IJSon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ijson_160x160.png"
+  },
+  {
+    "name": "iShares US Technology ETF (Ondo Tokenized)",
+    "address": "vr8RQPDmYQBruiYsFSV3KZyoWFEsEejxzMCdWrBondo",
+    "symbol": "IYWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/iywon_160x160.png"
+  },
+  {
+    "name": "Global X S&P 500 Covered Call ETF (Ondo Tokenized)",
+    "address": "wCr7YFeYDWyYSebsoMY75g8c9pguGeVB3rT6kYjondo",
+    "symbol": "XYLDon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/xyldon_160x160.png"
+  },
+  {
+    "name": "SPDR Bloomberg 1-3 Month T-Bill ETF (Ondo Tokenized)",
+    "address": "wtwpt5yJbButAhjpYhtg4uvUgCQN4LVgvLq2AxEondo",
+    "symbol": "BILon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/bilon_160x160.png"
+  },
+  {
+    "name": "iShares 3-7 Year Treasury Bond ETF (Ondo Tokenized)",
+    "address": "wuzf2FDZTRbRY3ZnndMeQ38Wk9YTDGGXTA63nUyondo",
+    "symbol": "IEIon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ieion_160x160.png"
+  },
+  {
+    "name": "iShares Systematic Bond ETF (Ondo Tokenized)",
+    "address": "5U9o49BoQNU6bBMswvmBs3R4GZmYSyrnTN4ncX4ondo",
+    "symbol": "SYSBon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/sysbon_160x160.png"
+  },
+  {
+    "name": "iShares Securitized Income Active ETF (Ondo Tokenized)",
+    "address": "sDtEN5uwUJJCFJ95x2rPjPqNx5UWUbHQ2ucceUzondo",
+    "symbol": "SECUon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/secuon_160x160.png"
+  },
+  {
+    "name": "iShares High Yield Corporate Bond BuyWrite Strategy ETF (Ondo Tokenized)",
+    "address": "ZKzkbFi4n3NQmRA9i5T7jVPSN2XERwxfHUf4p2pondo",
+    "symbol": "HYGWon",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hygwon_160x160.png"
   }
 ]


### PR DESCRIPTION
## Why

Ondo reported that most of their tokenized-equity ("GM") token icons are missing in Jumper, and that a high percentage show warning signs — worst of all on Solana. Verified against `/v1/tokens`:

| Chain | missing `logoURI` | `verificationStatus: unverified` |
|---|---|---|
| Ethereum | 299 / 442 | 0 |
| BSC | 395 / 436 | 176 |
| **Solana** | **399 / 442** | **356** |
| HyperEVM | 24 / 35 | 35 |

## What this PR does

Adds the issuer's own CDN logos (160×160 PNG, matching the convention already used for Ondo entries here) for **1,044 tokens**: 300 ETH, 320 BSC, 400 SOL, 24 HYP.

That count includes the **8 tokens missing from the token list entirely** — notably **`USDon`**, Ondo's stablecoin, absent on ETH, BSC *and* SOL (`/v1/token` returned `code: 1003`). For those 8 this list change is sufficient on its own, since the fetch job's insert path handles new tokens.

## ⚠️ This PR alone does not fix the other ~1,035 tokens

The token fetch job reads only `address` and `chainId` from this list and **discards `logoURI`** ([`tokenService.fetch.custom.token.helpers.ts#L85-L99`](https://github.com/lifinance/lifi-backend/blob/develop/apps/backend-api/src/packages/TokenService/fetch/tokenService.fetch.custom.token.helpers.ts#L85-L99)), and it writes via `insertOne` only — tokens already in `StaticToken` are skipped ([`tokenService.get.job.ts#L57`](https://github.com/lifinance/lifi-backend/blob/develop/apps/backend-api/src/packages/TokenServiceJobs/get/tokenService.get.job.ts#L57)).

Direct evidence: **82 of the BSC tokens in this set were already in `tokens/BSC.json` with correct Ondo logos and still return no `logoURI`.** The list route has already been tried for them and never took effect.

So after merge:
1. Wait ~1h for the custom-list cache to expire ([`customListOracle.utils.ts#L52`](https://github.com/lifinance/lifi-backend/blob/develop/apps/backend-api/src/packages/CustomListOracle/customListOracle.utils.ts#L52)).
2. Run a `PATCH /v1/token?chain=&token=` sweep over the affected addresses — that's the only path that ignores the DB and re-runs the oracle chain including `customListOracle` ([`api.services.ts#L161`](https://github.com/lifinance/lifi-backend/blob/develop/apps/backend-api/src/api/api.services.ts#L161)).

The warning signs are a **separate** issue and are not addressed here — they need `POST /v1/token/rescreen` for the 567 `unverified` tokens. Being in this list does not change `verificationStatus`.

## Verification

- ✅ `npx jest` — 2,969 tests pass
- ✅ `npx prettier --check` on all four touched files (`FLW.json`/`XDC.json` warnings are pre-existing on `main`, untouched)
- ✅ All **433 unique CDN URLs return HTTP 200**
- ✅ Decimals sourced from the API and spot-verified on-chain (`eth_call 0x313ce567`, Solana `getAccountInfo`)
- ✅ Append-only — verified the original array is a byte-identical prefix of each new file; no existing entry modified, none lost
- ✅ No duplicate addresses introduced; none of these are on a deny list

## Notes for the reviewer

- **`AALon`**: Ondo's sheet points it at `abton_*.svg` (Abbott) instead of `aalon_*` (American Airlines). This repo already used `aalon_160x160.png`, so I followed that precedent. Worth flagging back to Ondo to fix their sheet.
- **Pre-existing data bug, not fixed here**: on BSC, `NIKLon` (Sprott Nickel Miners) and `PALLon` (abrdn Physical Palladium) both claim address `0x3fcd741646a9790635b938cdb69af5df356cbaab`. One is wrong — worth its own ticket.
