### PR TITLE
fix: correct malformed wPCN logoURI on BSC (#742)

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -2066,7 +2066,7 @@
   {
     "address": "0x290A5779a419Cb9cB22fa087CDD1CD16dA2D95F1",
     "chainId": 56,
-    "logoURI": "https://pc.am/brand/wpcn-round-256.png\n\n(256×256 PNG, transparent background, served from our own domain — permanent, no signing or expiry. An SVG source is at https://pc.am/brand/wpcn-round.svg and 32/64/128/512 px variants exist at the same path pattern.)",
+    "logoURI": "https://pc.am/brand/wpcn-round-256.png",
     "decimals": 8,
     "name": "Wrapped PCoin",
     "symbol": "wPCN"


### PR DESCRIPTION
Fixes the `logoURI` for wPCN on BSC, reported in #742 (added via #745).

## Problem

The `/add-token` issue parser took everything under the `### Logo URL` heading, so the merged entry got the URL **plus two newlines plus an explanatory paragraph**:

```
"logoURI": "https://pc.am/brand/wpcn-round-256.png\n\n(256×256 PNG, transparent background, served from our own domain — permanent, no signing or expiry. An SVG source is at https://pc.am/brand/wpcn-round.svg and 32/64/128/512 px variants exist at the same path pattern.)"
```

That is not a resolvable URI, so the API drops the field entirely and the icon renders blank everywhere the list is consumed:

```
$ curl -s 'https://li.quest/v1/token?chain=56&token=0x290A5779a419Cb9cB22fa087CDD1CD16dA2D95F1'
# symbol wPCN, priceUSD present, logoURI absent
```

## Change

One line in `tokens/BSC.json` — `logoURI` is now just the URL. Every other field in the entry (address, `chainId` 56, `decimals` 8, name, symbol) was already correct and is untouched.

## Verification

- `https://pc.am/brand/wpcn-round-256.png` returns `200 image/png`, 12,002 bytes, 256×256 with a transparent background.
- wPCN was the **only one of 2,337 tokens** across all files with whitespace in `logoURI`:
  ```
  jq -r '.[] | select(.logoURI | test("\n")) | .symbol' tokens/BSC.json   # -> wPCN
  ```
  After this change, zero remain.
- `pnpm run test` — 2996 passed.

## Note on why CI didn't catch it

`schema/tokenExpectedSchema.json` types `logoURI` as a bare `{"type": "string"}`, so a string containing newlines and prose validates cleanly. Adding `"pattern": "^https://\\S+$"` would reject it with no new dependency (`ajv-formats` isn't in `package.json`, so `"format": "uri"` would need that added first). I verified all 2,337 existing values pass that pattern, so it can be added without touching any other entry — leaving it out of this PR to keep the fix minimal, happy to open it separately.

Thanks to @pars5555 for reporting it clearly and for the schema suggestion.