### PR TITLE
feat: add LAPTOP on Base

### DIFF
--- a/tokens/BAS.json
+++ b/tokens/BAS.json
@@ -1246,5 +1246,13 @@
     "decimals": 18,
     "name": "Staked Vetro BTC",
     "symbol": "svetBTC"
+  },
+  {
+    "address": "0xB095274743941e953c746F9C228DA9c18Bb6ec29",
+    "chainId": 8453,
+    "logoURI": "https://assets.coingecko.com/coins/images/102176837/standard/Laptop_Logo.png",
+    "decimals": 18,
+    "name": "LAPTOP",
+    "symbol": "LAPTOP"
   }
 ]


### PR DESCRIPTION
## Summary

Adds LAPTOP (`0xB095274743941e953c746F9C228DA9c18Bb6ec29`) to `tokens/BAS.json` (Base, chainId 8453).

## Source

- [x] **Internal request** — added by an internal team member (no upstream issue)
- [ ] **Partner / external request** — fulfils issue #<number>, partner: `<partner name>`

## ⚠️ Review script result: 3 blockers — do not merge as-is

`node scripts/review-token-listing.mjs 8453 0xB095274743941e953c746F9C228DA9c18Bb6ec29 <logoURI>`

| Check | Result |
|---|---|
| EIP-55 checksum | ✅ PASS |
| `name()` / `symbol()` / `decimals()` | ✅ PASS — `LAPTOP` / `LAPTOP` / `18` |
| Logo URI reachable | ✅ PASS — HTTP 200 |
| Buy tax / sell tax | ✅ PASS — none detected |
| **priceUSD** | ❌ **FAIL** — `$0.0000000001` (MinimalPriceOracle fallback) |
| **Pricing providers** | ❌ **FAIL** — no data from LI.FI, CoinGecko, DexScreener or Zapper |
| **Source verified** | ❌ **FAIL** — GoPlus `is_open_source: 0` |

### Why there is no price: the token has not launched yet

- **1 holder.** GoPlus reports `holder_count: 1`. The single holder is `0xf859bf7a72a282eac0e99e1ca0d1b814ccd8b24d`, holding 100% of the 1,000,000,000 supply. `eth_getCode` on that address returns the 171-byte Gnosis Safe proxy bytecode (dispatches on the `masterCopy()` selector `0xa619486e`), so the whole supply is sitting in a multisig treasury.
- **No DEX liquidity.** GoPlus reports `is_in_dex: 0`. DexScreener returns zero pairs for the token on Base.
- **CoinGecko is a preview listing.** `GET /api/v3/coins/base/contract/0xB095…` returns `preview_listing: true` with `market_data: null` — CG has the metadata page and the logo, but no price feed.
- **LI.FI already serves the fallback.** `GET https://li.quest/v1/token?chain=8453&token=0xB095…` returns `priceUSD: "0.0000000001"`, `marketCapUSD: null`, `volumeUSD24H: null`, `verificationStatus: "unverified"`.

Per `REVIEW_PROCESS.md` §2.5 and the Step 3 decision matrix, a token whose only price is the `~$1e-10` fallback triggers ~100% price impact on every route and gets filtered out — so merging this today lists the token without making it routable.

### Suggested handling

Hold this PR until the treasury Safe seeds a pool and a pricing provider picks the token up, then re-run the review script. It should flip to PASS on its own once there is liquidity; nothing in the JSON needs to change.

### Note on `name`

I used the on-chain `name()` verbatim (`"LAPTOP"`) so the review script's §2.4 check stays clean. CoinGecko lists this contract as **"Hunter Biden's Laptop"** (`hunter-biden-s-laptop-3`) — if the team would rather the list display that, say so and I'll change the `name` field.

## Checklist

- [x] JSON validates (CI will confirm) — `npx jest` 2997/2997 pass locally
- [x] Logo URL is reachable and renders correctly — HTTP 200
- [x] Token contract address is checksummed — ⚠️ but **not** verified on the block explorer (GoPlus `is_open_source: 0`)
- [x] If this fulfils an external issue, the issue is linked above and will auto-close on merge — n/a, internal request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
