### PR TITLE
feat: add 8 Ondo tokenized RWA assets on ETH, BSC, Solana (24 entries)

### DIFF
--- a/tokens/BSC.json
+++ b/tokens/BSC.json
@@ -4662,5 +4662,69 @@
     "decimals": 18,
     "name": "Staked Vetro BTC",
     "symbol": "svetBTC"
+  },
+  {
+    "address": "0x97B2FD5fC2F3e0dfD72D45734e360961528B6c63",
+    "chainId": 56,
+    "symbol": "HYDBon",
+    "decimals": 18,
+    "name": "iShares High Yield Systematic Bond ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hydbon_160x160.png"
+  },
+  {
+    "address": "0xc992e5f8dA1b99cB941B0a259bE9014CFfE89Ccf",
+    "chainId": 56,
+    "symbol": "USHYon",
+    "decimals": 18,
+    "name": "iShares Broad USD High Yield Corporate Bond ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ushyon_160x160.png"
+  },
+  {
+    "address": "0x031d85943ba7ca0304323195e7086a76c35366fB",
+    "chainId": 56,
+    "symbol": "NEARon",
+    "decimals": 18,
+    "name": "iShares Short Duration Bond Active ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nearon_160x160.png"
+  },
+  {
+    "address": "0x817f1f6780F99BCaAc394A59CB0261962df5Da8b",
+    "chainId": 56,
+    "symbol": "GOOGon",
+    "decimals": 18,
+    "name": "Alphabet Inc. Class C (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/googon_160x160.png"
+  },
+  {
+    "address": "0xCB6D74afF24AFc94514727eE0FCDA6bb6B64f3F9",
+    "chainId": 56,
+    "symbol": "RXRXon",
+    "decimals": 18,
+    "name": "Recursion Pharmaceuticals (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rxrxon_160x160.png"
+  },
+  {
+    "address": "0xB18C6A83490DDDbc9A83b011173b5B2Fb5dC1272",
+    "chainId": 56,
+    "symbol": "HTZon",
+    "decimals": 18,
+    "name": "Hertz Global Holdings (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/htzon_160x160.png"
+  },
+  {
+    "address": "0x79ed7f4d9668E8e7AaadD12A711d19064840B9A5",
+    "chainId": 56,
+    "symbol": "WENon",
+    "decimals": 18,
+    "name": "Wendy's (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wenon_160x160.png"
+  },
+  {
+    "address": "0xBb8c10f7E828E3279df8CC3397A5212F845C509b",
+    "chainId": 56,
+    "symbol": "AIon",
+    "decimals": 18,
+    "name": "C3.ai (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aion_160x160.png"
   }
 ]

--- a/tokens/ETH.json
+++ b/tokens/ETH.json
@@ -3742,5 +3742,69 @@
     "decimals": 18,
     "name": "MemeCoinGirl",
     "symbol": "MIKO"
+  },
+  {
+    "address": "0xe109dFbF450eC2b9944900830b8DA22EaA59F1A3",
+    "chainId": 1,
+    "symbol": "HYDBon",
+    "decimals": 18,
+    "name": "iShares High Yield Systematic Bond ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hydbon_160x160.png"
+  },
+  {
+    "address": "0x6830f7BBFD274e393a32846918DA9De210879AE4",
+    "chainId": 1,
+    "symbol": "USHYon",
+    "decimals": 18,
+    "name": "iShares Broad USD High Yield Corporate Bond ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ushyon_160x160.png"
+  },
+  {
+    "address": "0x7E37ac5d67ebe99851193CD036D7725b6730c53D",
+    "chainId": 1,
+    "symbol": "NEARon",
+    "decimals": 18,
+    "name": "iShares Short Duration Bond Active ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nearon_160x160.png"
+  },
+  {
+    "address": "0x36B90aDcDC99Be31BF39A3c031288bAa0B457E10",
+    "chainId": 1,
+    "symbol": "GOOGon",
+    "decimals": 18,
+    "name": "Alphabet Inc. Class C (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/googon_160x160.png"
+  },
+  {
+    "address": "0xDaA3b81a3ACFcB60b875eBA1D26852376BC38486",
+    "chainId": 1,
+    "symbol": "RXRXon",
+    "decimals": 18,
+    "name": "Recursion Pharmaceuticals (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rxrxon_160x160.png"
+  },
+  {
+    "address": "0x7E95779D2d7B4a654A4ac80cB6423aE8998Cf1e7",
+    "chainId": 1,
+    "symbol": "HTZon",
+    "decimals": 18,
+    "name": "Hertz Global Holdings (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/htzon_160x160.png"
+  },
+  {
+    "address": "0x613518b520241f90c3E023Bb6006c63A5019CA7B",
+    "chainId": 1,
+    "symbol": "WENon",
+    "decimals": 18,
+    "name": "Wendy's (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wenon_160x160.png"
+  },
+  {
+    "address": "0x4554ad55ccA5e7CB97B77813f486aAf6D4D9AB62",
+    "chainId": 1,
+    "symbol": "AIon",
+    "decimals": 18,
+    "name": "C3.ai (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aion_160x160.png"
   }
 ]

--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -3366,5 +3366,69 @@
     "decimals": 9,
     "chainId": 1151111081099710,
     "logoURI": "https://cdn.ondo.finance/tokens/logos/hygwon_160x160.png"
+  },
+  {
+    "address": "71VH3YQkjqqGxzwYvGhsCsJNQYzkMo9Rg72aVxqondo",
+    "chainId": 1151111081099710,
+    "symbol": "HYDBon",
+    "decimals": 9,
+    "name": "iShares High Yield Systematic Bond ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/hydbon_160x160.png"
+  },
+  {
+    "address": "aau4XCAZR6p9uC4vgdHdh4ip3oW5pr5PrNs3FJ8ondo",
+    "chainId": 1151111081099710,
+    "symbol": "USHYon",
+    "decimals": 9,
+    "name": "iShares Broad USD High Yield Corporate Bond ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/ushyon_160x160.png"
+  },
+  {
+    "address": "bD6TafGhPo8NaeKEyge1DrZGAPB5wxK3x4fCpqjondo",
+    "chainId": 1151111081099710,
+    "symbol": "NEARon",
+    "decimals": 9,
+    "name": "iShares Short Duration Bond Active ETF (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/nearon_160x160.png"
+  },
+  {
+    "address": "jcA9zXHWuTuDFDDDDYJTNhersed1B5etkuB6X9Eondo",
+    "chainId": 1151111081099710,
+    "symbol": "GOOGon",
+    "decimals": 9,
+    "name": "Alphabet Inc. Class C (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/googon_160x160.png"
+  },
+  {
+    "address": "q16ZLSbANUhpcq15pRUXRxNFfEqgpde9mSBwRcyondo",
+    "chainId": 1151111081099710,
+    "symbol": "RXRXon",
+    "decimals": 9,
+    "name": "Recursion Pharmaceuticals (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/rxrxon_160x160.png"
+  },
+  {
+    "address": "QApMAZTHvfhX2dTDzM8AMyAHVyhmPVwj4oY8Jveondo",
+    "chainId": 1151111081099710,
+    "symbol": "HTZon",
+    "decimals": 9,
+    "name": "Hertz Global Holdings (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/htzon_160x160.png"
+  },
+  {
+    "address": "QwJ619MuDRvT1f29RH7tMdaqsUnaSNcvBEJAZkHondo",
+    "chainId": 1151111081099710,
+    "symbol": "WENon",
+    "decimals": 9,
+    "name": "Wendy's (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/wenon_160x160.png"
+  },
+  {
+    "address": "rVMtUyy1ohurejV9qd81y9cPRHNA1A2QqWAErqfondo",
+    "chainId": 1151111081099710,
+    "symbol": "AIon",
+    "decimals": 9,
+    "name": "C3.ai (Ondo Tokenized)",
+    "logoURI": "https://cdn.ondo.finance/tokens/logos/aion_160x160.png"
   }
 ]


### PR DESCRIPTION
## Summary

Adds **8 Ondo tokenized RWA assets** across **Ethereum (1), BSC (56), Solana (1151111081099710)** — 24 entries total.

| Symbol | Underlying | Chains |
|--------|-----------|--------|
| HYDBon | iShares High Yield Systematic Bond ETF | ETH, BSC, SOL |
| USHYon | iShares Broad USD High Yield Corporate Bond ETF | ETH, BSC, SOL |
| NEARon | iShares Short Duration Bond Active ETF | ETH, BSC, SOL |
| GOOGon | Alphabet Inc. Class C | ETH, BSC, SOL |
| RXRXon | Recursion Pharmaceuticals | ETH, BSC, SOL |
| HTZon | Hertz Global Holdings | ETH, BSC, SOL |
| WENon | Wendy's | ETH, BSC, SOL |
| AIon | C3.ai | ETH, BSC, SOL |

## Verification

- **Logos:** all 8 `cdn.ondo.finance` logo URLs return **HTTP 200**.
- **Decimals (on-chain spot-check):** ETH/BSC = `18`, Solana = `9` — match the entries.
- **Solana mints:** `spl-token-2022` (Ondo RWA standard).
- No duplicate addresses vs. existing list.

After merge, the tokens propagate to the API within ~1h (custom-list cache TTL).

Made with [Cursor](https://cursor.com)