### PR TITLE
feat: add GTR (GETTR Token) to Solana token list

### DIFF
--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -3436,6 +3436,7 @@
     "chainId": 1151111081099710,
     "symbol": "GTR",
     "decimals": 9,
-    "name": "GETTR Token"
+    "name": "GETTR Token",
+    "logoURI": "https://assets.geckoterminal.com/hz68retmny0xesnfpvs56ciewjzq"
   }
 ]

--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -3430,5 +3430,12 @@
     "decimals": 9,
     "name": "C3.ai (Ondo Tokenized)",
     "logoURI": "https://cdn.ondo.finance/tokens/logos/aion_160x160.png"
+  },
+  {
+    "address": "CatEvkKVmK2fsiVJZ3EzEBuCW8bmNoHKxsXvbBggdebp",
+    "chainId": 1151111081099710,
+    "symbol": "GTR",
+    "decimals": 9,
+    "name": "GETTR Token"
   }
 ]


### PR DESCRIPTION
Adds the `GTR` mint to `tokens/SOL.json`.

**Requested by:** integrator Mtransform, who reported "no routes for this token".

## Why

Routing already works — this is purely a token-list visibility issue. Verified live:

| Pair | Result |
|---|---|
| USDC (Base) → GTR (Solana), $100 | 4 routes — `mayanFastMCTP`, `mayan`, `relaydepository`, `mayanMCTP` |
| USDC (Base) → GTR (Solana), $1 | 2 routes |
| GTR → USDC (same-chain, Solana) | `jupiter` |
| SOL → GTR (same-chain) | `jupiter` |

The token is tagged `unknown` on Jupiter, and our only SVM list source requests `tags=[verified]`, so GTR was never ingested from a real source. It exists in the DB only from a `/v1/token` lazy-load, giving it `origins: ["User"]` → `isUserAddedToken: true` → excluded from `/v1/tokens` (unless `?search=` is passed) and unconditionally from `/v1/connections`.

Merging this sets origin `CustomTokenLists`, so the flag recomputes to `false` and the token appears in both endpoints.

## Token data

On-chain verified via `getAccountInfo`: standard SPL Token program, 9 decimals, mint authority disabled, **no freeze authority**, no Token-2022 extensions.

## On the logo

The upstream Arweave asset referenced by the mint metadata (`arweave.net/d44az0KRBBxiWiBcBcr-xmtEwh3-mJMxjGIFXBEPgrU`, which is also what Jupiter serves) is a **dead link — HTTP 404**, and alternate Arweave gateways do not resolve it.

This entry therefore uses the GeckoTerminal-hosted asset instead: `https://assets.geckoterminal.com/hz68retmny0xesnfpvs56ciewjzq` — verified HTTP 200, 250x250 PNG, confirmed to be the real GETTR torch mark, on a host already used elsewhere in this repo.

Note that because the token already has a DB record, merging this will make it **visible** but will not backfill the corrected logo on its own — that needs a follow-up `PATCH /v1/token`.

## Risk signal — flagged for a judgement call

Jupiter reports the first liquidity pool for this mint was created **2026-09-09** (the same day as the request) with **~99.5% top-holder concentration**. That is why Jupiter has not verified it.

Partners are already unblocked without this PR by passing `?search=` to `/v1/tokens`, so there is no urgency if we would rather let the token age first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)