### PR TITLE
feat: add Wrapped 0G (W0G) on Solana

### DIFF
--- a/tokens/SOL.json
+++ b/tokens/SOL.json
@@ -3438,5 +3438,13 @@
     "decimals": 9,
     "name": "GETTR Token",
     "logoURI": "https://assets.geckoterminal.com/hz68retmny0xesnfpvs56ciewjzq"
+  },
+  {
+    "name": "Wrapped 0G",
+    "address": "gNyJyS9pQt33o4y4L3gdWZAF2XHgPrCBRQuaiCZStMe",
+    "symbol": "W0G",
+    "decimals": 9,
+    "chainId": 1151111081099710,
+    "logoURI": "https://arweave.net/WouRoKxTv3LtESHGqdFrdjDqHpZxWxgdhHPTIUqLv60"
   }
 ]


### PR DESCRIPTION
Adds Chainlink CCIP Wrapped 0G (W0G) on Solana, requested by the 0G team.

```json
{
  "name": "Wrapped 0G",
  "address": "gNyJyS9pQt33o4y4L3gdWZAF2XHgPrCBRQuaiCZStMe",
  "symbol": "W0G",
  "decimals": 9,
  "chainId": 1151111081099710,
  "logoURI": "https://arweave.net/WouRoKxTv3LtESHGqdFrdjDqHpZxWxgdhHPTIUqLv60"
}
```

## Verification

- `decimals: 9`, name and symbol match the on-chain SPL mint (`getAccountInfo`) and Jupiter's metadata
- `logoURI` returns HTTP 200, `image/png`, 16.6 KB — Jupiter's own icon URL
- Base58 address left uncased, matching the existing SOL entries

## Reviewer note on the review script

`scripts/review-token-listing.mjs` reports a bogus blocker for this token: `Address should be 0xgnyjys9pqt33...`. It is applying EIP-55 checksumming to a base58 Solana address. Please disregard that line — worth a separate fix to the script.

## Known caveats, accepted deliberately

Merging this against `REVIEW_PROCESS.md` §2.5 is a conscious call, so the reasoning is on the record:

1. **No price coverage.** No pricing provider (CoinGecko, DexScreener, Zapper, Jupiter) has data for this mint. The token will list but stay outside the default token list, since it fails the widget's `minPriceUSD` gate, and routes will be filtered by price impact. Listing it still moves `/v1/token` from `1003 Could not find token` to returning the token, which makes it findable and selectable in Jumper — that is the intent here.
2. **Authority setup.** The mint authority is a 1-of-2 SPL multisig whose signers are `9KSufp17ry6r9SvDbD9rDAgvMoY35YwSzJQBRXJiyRJ2` and `EMDVTzb6fnMXzKap96KNP4McboySUHYs286iq5JydXwP`. The latter is also the mint's freeze authority, so a single keypair can both mint and freeze holder balances. Raised with 0G as a follow-up.

Solana is in `HYPERNATIVE_CHAIN_MAP`, so this token will be screened within ~15 minutes of landing and may come back `flagged`. That outcome is expected and accepted; follow-up with 0G will happen separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)